### PR TITLE
Clarify README and add private_key_pem credential field

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,12 @@ from your repository and publish it into `AGENTS`.
 
 ## Getting Started
 
-Start by publishing one source into `AGENTS`, then point an agent at the
-warehouse and let it inspect the metadata directly. The fastest path is usually
-dbt: if your repo already produces `target/manifest.json`, the workflow only
-needs the dbt project path and your warehouse credentials.
+Run one of the workflows below to populate the `AGENTS` schema from a source
+you already have. Once it's populated, anything that already queries your
+warehouse can read those tables as ordinary SQL, including Cursor, Claude
+Code, notebooks, and internal agents. The fastest path is usually dbt: if your
+repo already produces `target/manifest.json`, the workflow only needs the dbt
+project path and your warehouse credentials.
 
 After the first run, your warehouse has queryable metadata tables such as
 `AGENTS.DBT_MODEL` and `AGENTS.DBT_COLUMN`. Agents can use those tables to
@@ -94,12 +96,27 @@ database: ANALYTICS
 role: TRANSFORMER
 ```
 
-`role` is optional. For key-pair auth, use `private_key_path` and optional
-`private_key_passphrase` instead of `password`.
+For key-pair auth, replace `password` with `private_key_path` and optionally
+`private_key_passphrase`:
 
-The destination object configures where Agents Schema writes. It does not
-rename the schema; ingestion writes to `AGENTS`. The destination user needs
-permission to create or replace tables in that schema.
+```json
+{
+  "type": "snowflake",
+  "account": "abc123",
+  "user": "AGENTS_SCHEMA_BOT",
+  "private_key_path": "/path/to/rsa_key.p8",
+  "private_key_passphrase": "optional",
+  "warehouse": "COMPUTE_WH",
+  "database": "ANALYTICS",
+  "role": "TRANSFORMER"
+}
+```
+
+`role` is optional.
+
+The destination object configures the warehouse and connection. The schema
+name is always `AGENTS`. The destination user needs permission to create or
+replace tables in that schema.
 
 `WAREHOUSE_CREDENTIALS` is only the destination for writing `AGENTS`. If the
 workflow needs to run dbt, the dbt adapter is selected from the dbt profile, not
@@ -267,11 +284,10 @@ this information often lives in wikis, Slack threads, dashboards, and tribal
 knowledge. Agents Schema puts it in the warehouse itself, where agents can find
 it without leaving the query interface.
 
-Agents Schema is primarily a discovery and orientation layer for agents working
-from inside a warehouse query surface. It gives agents a standard place to
-answer questions like what curated tables exist, which system published the
-metadata, what dbt model or LookML object represents a dataset, whether a
-source is stale, and who owns a data product.
+Agents Schema is a discovery layer for agents that already query your
+warehouse. It gives them a standard place to ask: what curated tables exist,
+which system published the metadata, what dbt model or LookML object backs a
+dataset, whether a source is stale, and who owns a data product.
 
 The schema is self-documenting. `AGENTS.ROOT` tells consumers which providers
 are present and explains what provider-contributed tables mean. Consumers can

--- a/README.md
+++ b/README.md
@@ -69,8 +69,11 @@ workflows:
 WAREHOUSE_CREDENTIALS
 ```
 
-Snowflake is the only supported destination today, with more destination support
-coming soon. For Snowflake, the secret value can be JSON:
+Snowflake is the only supported destination today, with more destination
+support coming soon. The secret value is a JSON or YAML object. Choose one of
+the two auth methods:
+
+**Password auth:**
 
 ```json
 {
@@ -84,23 +87,22 @@ coming soon. For Snowflake, the secret value can be JSON:
 }
 ```
 
-or YAML:
+**Key-pair auth:**
 
-```yaml
-type: snowflake
-account: abc123
-user: AGENTS_SCHEMA_BOT
-warehouse: COMPUTE_WH
-database: ANALYTICS
-role: TRANSFORMER
-# Choose one auth method:
-password: secret
-# private_key_path: /path/to/rsa_key.p8
-# private_key_passphrase: optional
+```json
+{
+  "type": "snowflake",
+  "account": "abc123",
+  "user": "AGENTS_SCHEMA_BOT",
+  "warehouse": "COMPUTE_WH",
+  "database": "ANALYTICS",
+  "role": "TRANSFORMER",
+  "private_key_pem": "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
+}
 ```
 
-For key-pair auth in JSON, replace `password` with `private_key_path` and
-optionally `private_key_passphrase`. `role` is optional.
+`role` is optional. Add `private_key_passphrase` to the key-pair object if the
+key is encrypted. YAML works with the same field names.
 
 The destination object configures the warehouse and connection. The schema
 name is always `AGENTS`. The destination user needs permission to create or

--- a/README.md
+++ b/README.md
@@ -95,13 +95,15 @@ warehouse: COMPUTE_WH
 database: ANALYTICS
 role: TRANSFORMER
 private_key_pem: |
-  -----BEGIN PRIVATE KEY-----
+  -----BEGIN ENCRYPTED PRIVATE KEY-----
   MIIEvQIBADANBgkqh...
-  -----END PRIVATE KEY-----
+  -----END ENCRYPTED PRIVATE KEY-----
+private_key_passphrase: your-passphrase   # only if the key is encrypted
 ```
 
-`role` is optional. Add `private_key_passphrase` to the key-pair object if the
-key is encrypted. JSON works with the same field names.
+`role` is optional. An unencrypted key uses `-----BEGIN PRIVATE KEY-----` /
+`-----END PRIVATE KEY-----` markers (without `ENCRYPTED`) and omits
+`private_key_passphrase`. JSON works with the same field names.
 
 The destination object configures the warehouse and connection. The schema
 name is always `AGENTS`. The destination user needs permission to create or

--- a/README.md
+++ b/README.md
@@ -6,20 +6,22 @@ can query metadata next to the data they are reasoning over. See
 [Why Agents Schema](#why-agents-schema) for more on the idea behind it and
 [SPEC.md](./SPEC.md) for the schema contract.
 
-This repository provides GitHub reusable workflows that ingest source metadata
-from your repository and publish it into `AGENTS`.
+This repository provides GitHub workflows that ingest source metadata from
+your repository and publish it into `AGENTS`.
 
 ![Agents Schema overview](assets/agents-schema-overview.png)
 
 ## Contents
 
 - [Getting Started](#getting-started)
+  - [Supported Metadata Sources](#supported-metadata-sources)
   - [Prerequisites](#prerequisites)
 - [Guides](#guides)
   - [Sync dbt](#sync-dbt)
   - [Sync Looker](#sync-looker)
   - [Sync Multiple Sources](#sync-multiple-sources)
 - [Why Agents Schema](#why-agents-schema)
+  - [How it works](#how-it-works)
 - [Reference](#reference)
   - [CLI](#cli)
   - [Versioning](#versioning)
@@ -39,18 +41,6 @@ After the first run, your warehouse has queryable metadata tables such as
 understand which models exist, how they are documented, how they relate to the
 warehouse, and what context is available before writing or explaining queries.
 
-The workflow shape is:
-
-1. Your repository calls one of this repo's reusable GitHub workflows.
-2. The workflow checks out your repository and reads source metadata, such as
-   dbt artifacts or LookML files.
-3. The workflow runs the `agents-schema` CLI from this repository at the pinned
-   release tag.
-4. The CLI writes normalized metadata into the warehouse under the fixed
-   `AGENTS` schema.
-5. Agents and downstream tools query `AGENTS` to discover context close to the
-   data itself.
-
 ### Supported Metadata Sources
 
 - dbt: reads `target/manifest.json` and writes `AGENTS.DBT_*` tables.
@@ -58,9 +48,7 @@ The workflow shape is:
 
 More sources coming soon.
 
-## Prerequisites
-
-### Warehouse Credentials
+### Prerequisites
 
 Create one required GitHub Actions secret in the repository that calls these
 workflows:
@@ -117,7 +105,7 @@ from these destination credentials.
 
 ### Sync dbt
 
-Use the dbt reusable workflow when the repository contains a dbt project.
+Use the dbt workflow when the repository contains a dbt project.
 
 #### Use an Existing Manifest
 
@@ -217,7 +205,7 @@ parse command, it fails with an explicit error.
 
 ### Sync Looker
 
-Use the Looker reusable workflow when the repository contains LookML files:
+Use the Looker workflow when the repository contains LookML files:
 
 ```yaml
 name: Agents Schema Looker
@@ -239,7 +227,7 @@ The workflow reads `*.lkml` files from `lookml-dir`.
 
 ### Sync Multiple Sources
 
-Use separate reusable workflows in the same GitHub Actions workflow:
+Run the workflows from the same workflow file:
 
 ```yaml
 name: Agents Schema dbt + Looker
@@ -295,6 +283,17 @@ It is closest in spirit to `information_schema`, but extensible across many
 providers. Compared with MCP servers, Agents Schema is narrower: it publishes
 context inside the warehouse, while MCP servers can expose tools, actions, and
 source-specific workflows.
+
+### How it works
+
+1. A workflow in your repository invokes one of this repo's workflows.
+2. The workflow checks out your repository and reads source metadata such as
+   dbt artifacts or LookML files.
+3. The workflow runs the `agents-schema` CLI at the pinned release tag.
+4. The CLI writes normalized metadata into the warehouse under the `AGENTS`
+   schema.
+5. Agents and downstream tools query `AGENTS` for context close to the data
+   itself.
 
 ## Reference
 

--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ coming soon. For Snowflake, the secret value can be JSON:
   "type": "snowflake",
   "account": "abc123",
   "user": "AGENTS_SCHEMA_BOT",
-  "password": "secret",
   "warehouse": "COMPUTE_WH",
   "database": "ANALYTICS",
-  "role": "TRANSFORMER"
+  "role": "TRANSFORMER",
+  "password": "secret"
 }
 ```
 
@@ -90,29 +90,17 @@ or YAML:
 type: snowflake
 account: abc123
 user: AGENTS_SCHEMA_BOT
-password: secret
 warehouse: COMPUTE_WH
 database: ANALYTICS
 role: TRANSFORMER
+# Choose one auth method:
+password: secret
+# private_key_path: /path/to/rsa_key.p8
+# private_key_passphrase: optional
 ```
 
-For key-pair auth, replace `password` with `private_key_path` and optionally
-`private_key_passphrase`:
-
-```json
-{
-  "type": "snowflake",
-  "account": "abc123",
-  "user": "AGENTS_SCHEMA_BOT",
-  "private_key_path": "/path/to/rsa_key.p8",
-  "private_key_passphrase": "optional",
-  "warehouse": "COMPUTE_WH",
-  "database": "ANALYTICS",
-  "role": "TRANSFORMER"
-}
-```
-
-`role` is optional.
+For key-pair auth in JSON, replace `password` with `private_key_path` and
+optionally `private_key_passphrase`. `role` is optional.
 
 The destination object configures the warehouse and connection. The schema
 name is always `AGENTS`. The destination user needs permission to create or

--- a/README.md
+++ b/README.md
@@ -70,39 +70,38 @@ WAREHOUSE_CREDENTIALS
 ```
 
 Snowflake is the only supported destination today, with more destination
-support coming soon. The secret value is a JSON or YAML object. Choose one of
+support coming soon. The secret value is a YAML or JSON object. Choose one of
 the two auth methods:
 
 **Password auth:**
 
-```json
-{
-  "type": "snowflake",
-  "account": "abc123",
-  "user": "AGENTS_SCHEMA_BOT",
-  "warehouse": "COMPUTE_WH",
-  "database": "ANALYTICS",
-  "role": "TRANSFORMER",
-  "password": "secret"
-}
+```yaml
+type: snowflake
+account: abc123
+user: AGENTS_SCHEMA_BOT
+warehouse: COMPUTE_WH
+database: ANALYTICS
+role: TRANSFORMER
+password: secret
 ```
 
 **Key-pair auth:**
 
-```json
-{
-  "type": "snowflake",
-  "account": "abc123",
-  "user": "AGENTS_SCHEMA_BOT",
-  "warehouse": "COMPUTE_WH",
-  "database": "ANALYTICS",
-  "role": "TRANSFORMER",
-  "private_key_pem": "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
-}
+```yaml
+type: snowflake
+account: abc123
+user: AGENTS_SCHEMA_BOT
+warehouse: COMPUTE_WH
+database: ANALYTICS
+role: TRANSFORMER
+private_key_pem: |
+  -----BEGIN PRIVATE KEY-----
+  MIIEvQIBADANBgkqh...
+  -----END PRIVATE KEY-----
 ```
 
 `role` is optional. Add `private_key_passphrase` to the key-pair object if the
-key is encrypted. YAML works with the same field names.
+key is encrypted. JSON works with the same field names.
 
 The destination object configures the warehouse and connection. The schema
 name is always `AGENTS`. The destination user needs permission to create or

--- a/src/agents_schema/destinations.py
+++ b/src/agents_schema/destinations.py
@@ -154,9 +154,10 @@ def _snowflake_connect_kwargs_from_secret(destination: dict[str, Any]) -> dict[s
     required = ["account", "user", "warehouse", "database"]
     missing = [name for name in required if not destination.get(name)]
     has_password = bool(destination.get("password"))
-    has_private_key = bool(destination.get("private_key_path"))
-    if not has_password and not has_private_key:
-        missing.append("password or private_key_path")
+    has_private_key_pem = bool(destination.get("private_key_pem"))
+    has_private_key_path = bool(destination.get("private_key_path"))
+    if not has_password and not has_private_key_pem and not has_private_key_path:
+        missing.append("password, private_key_pem, or private_key_path")
     if missing:
         raise ConfigError("WAREHOUSE_CREDENTIALS missing keys: " + ", ".join(missing))
 
@@ -168,21 +169,27 @@ def _snowflake_connect_kwargs_from_secret(destination: dict[str, Any]) -> dict[s
     }
     if role := destination.get("role"):
         kwargs["role"] = role
-    if has_private_key:
+    passphrase = destination.get("private_key_passphrase")
+    if has_private_key_pem:
         kwargs["private_key"] = _load_private_key(
-            Path(destination["private_key_path"]),
-            destination.get("private_key_passphrase"),
+            destination["private_key_pem"].encode(),
+            passphrase,
+        )
+    elif has_private_key_path:
+        kwargs["private_key"] = _load_private_key(
+            Path(destination["private_key_path"]).read_bytes(),
+            passphrase,
         )
     else:
         kwargs["password"] = destination["password"]
     return kwargs
 
 
-def _load_private_key(path: Path, passphrase: str | None) -> bytes:
+def _load_private_key(pem_bytes: bytes, passphrase: str | None) -> bytes:
     from cryptography.hazmat.primitives import serialization
 
     password = passphrase.encode() if passphrase else None
-    private_key = serialization.load_pem_private_key(path.read_bytes(), password=password)
+    private_key = serialization.load_pem_private_key(pem_bytes, password=password)
     return private_key.private_bytes(
         encoding=serialization.Encoding.DER,
         format=serialization.PrivateFormat.PKCS8,


### PR DESCRIPTION
## Summary

Two things, delivered together since the docs needed to follow the code shape:

1. **`private_key_pem` field in `WAREHOUSE_CREDENTIALS`** so key-pair auth works in CI without writing a PEM file onto the runner. The existing `private_key_path` field remains for local CLI use but is no longer documented as the primary path.
2. **README clarity and structure pass** addressing jargon-heavy openers, hidden auth options, the "reusable workflows" framing landing before the user had set anything up, and a TOC that did not match the heading hierarchy.

## Why

The README's Getting Started and Why sections opened with project-internal verbs ("publishing one source into AGENTS", "point an agent at the warehouse") that did not tell a customer what to do or what they would get. Key-pair auth was supported in code but only appeared in a trailing sentence after the password examples, so a reader scanning the example would not notice it. The path-based `private_key_path` field made key-pair auth awkward in CI because the reusable workflows do not expose a step for writing the PEM file to disk before the action runs. And "reusable workflows" appeared in the third sentence of the doc, contradicting the CEO note that reusability should not appear before the user has succeeded once.

## Code

### `private_key_pem` field in `WAREHOUSE_CREDENTIALS`

`destinations.py` now accepts the PEM contents inline in the secret value, so the credential is a single self-contained value pasted into a GitHub Secret with no file-on-runner step. Resolution order: `private_key_pem` > `private_key_path` > `password`. `private_key_path` remains supported for local CLI use. Verified with five behavior cases (missing auth, password-only, pem-only, path-only back-compat, pem precedes path).

## Documentation

### Getting Started opener
Replaced "Start by publishing one source into AGENTS, then point an agent at the warehouse" with a sentence that names the action (run a workflow) and the result (any agent that already queries the warehouse can read AGENTS as ordinary SQL).

### Why Agents Schema opener
Replaced "primarily a discovery and orientation layer for agents working from inside a warehouse query surface" with "a discovery layer for agents that already query your warehouse."

### Credential section
- Switched examples from JSON to YAML to match the audience's daily format (dbt config, schema.yml, GitHub Actions workflows are all YAML).
- Two labeled examples: Password auth and Key-pair auth.
- Key-pair example shows encrypted PEM markers with `private_key_passphrase` inline plus a comment scoping its conditional nature. Trailing sentence covers the unencrypted variant.
- Removed defensive "It does not rename the schema" phrasing in favor of the positive statement that the schema name is always `AGENTS`.

### Held back the reusability framing
"Reusable workflows" appeared in the third sentence of the doc and in every Sync section opener. Dropped to "workflows" everywhere before Reference, leaving the reusability concept in the Versioning section where release-pinning makes it directly relevant.

### Moved the workflow-shape list out of Getting Started
The 5-step list described how the system works internally. Moved to a new `### How it works` subsection at the end of "Why Agents Schema," where a reader looking for mechanism finds it.

### TOC and heading hierarchy
Prerequisites was H2 in the body but nested under Getting Started in the TOC, so the link produced a surprising scroll. Prerequisites is now H3 under Getting Started, the single-child "Warehouse Credentials" heading is collapsed into the Prerequisites body, and the TOC also lists "Supported Metadata Sources" and the new "How it works" subsection.

## Intentionally out of scope

- **Snowflake OIDC / Workload Identity Federation.** The OIDC-based auth path that eliminates stored credentials entirely. Belongs in a follow-up that touches Snowflake-side configuration as much as repo code.
- **Customer-journey README restructure.** "Ingest your one source first, then add more" hierarchy is a larger piece. Pending artifacts (Snowflake Intelligence skill content, local Codex/Claude flow) before it can be done well.
- **Tests.** This repo has zero tests today. The fix for that is its own PR.
- **OSI documentation alignment.** `osi.py` exists but is not exposed in the README or workflows. Separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)