### PR TITLE
Require source directory inputs (dbt/Looker/OSI) and drop defaults

### DIFF
--- a/.github/actions/agents-schema-dbt/action.yml
+++ b/.github/actions/agents-schema-dbt/action.yml
@@ -5,8 +5,7 @@ description: >
 inputs:
   dbt-project-dir:
     description: 'Path to the dbt project containing target/manifest.json'
-    required: false
-    default: 'dbt_project'
+    required: true
   dbt-profile-name:
     description: 'dbt profile name to use for managed dbt parse when target/manifest.json is missing'
     required: false

--- a/.github/actions/agents-schema-looker/action.yml
+++ b/.github/actions/agents-schema-looker/action.yml
@@ -5,8 +5,7 @@ description: >
 inputs:
   lookml-dir:
     description: 'Path to a Looker project or directory containing *.lkml files'
-    required: false
-    default: 'lookml'
+    required: true
 runs:
   using: composite
   steps:

--- a/.github/actions/agents-schema-osi/action.yml
+++ b/.github/actions/agents-schema-osi/action.yml
@@ -5,8 +5,7 @@ description: >
 inputs:
   osi-dir:
     description: 'Path to a directory containing *.osi.yaml files'
-    required: false
-    default: 'osi'
+    required: true
 runs:
   using: composite
   steps:

--- a/.github/workflows/agents-schema-dbt.yml
+++ b/.github/workflows/agents-schema-dbt.yml
@@ -6,8 +6,7 @@ on:
       dbt-project-dir:
         description: 'Path to the dbt project containing target/manifest.json'
         type: string
-        required: false
-        default: dbt_project
+        required: true
       dbt-profile-name:
         description: 'dbt profile name to use for managed dbt parse when target/manifest.json is missing'
         type: string

--- a/.github/workflows/agents-schema-looker.yml
+++ b/.github/workflows/agents-schema-looker.yml
@@ -6,8 +6,7 @@ on:
       lookml-dir:
         description: 'Path to a Looker project or directory containing *.lkml files'
         type: string
-        required: false
-        default: lookml
+        required: true
     secrets:
       WAREHOUSE_CREDENTIALS:
         required: true

--- a/.github/workflows/agents-schema-osi.yml
+++ b/.github/workflows/agents-schema-osi.yml
@@ -6,8 +6,7 @@ on:
       osi-dir:
         description: 'Path to a directory containing *.osi.yaml files'
         type: string
-        required: false
-        default: osi
+        required: true
     secrets:
       WAREHOUSE_CREDENTIALS:
         required: true

--- a/dbt-setup.md
+++ b/dbt-setup.md
@@ -67,6 +67,10 @@ jobs:
     secrets: inherit
 ```
 
+`dbt-project-dir` is required — set it to the path of your dbt project (the
+directory that contains `dbt_project.yml`). The example uses `dbt_project`;
+change it to match your repository.
+
 The workflow looks for:
 
 ```text

--- a/looker-setup.md
+++ b/looker-setup.md
@@ -58,7 +58,8 @@ jobs:
     secrets: inherit
 ```
 
-The workflow reads `*.lkml` files from `lookml-dir`.
+`lookml-dir` is required — set it to the directory that contains your `*.lkml`
+files. The example uses `lookml`; change it to match your repository.
 
 These jobs do not need to depend on each other unless your repository has its
 own ordering requirement.

--- a/osi-setup.md
+++ b/osi-setup.md
@@ -55,8 +55,9 @@ jobs:
     secrets: inherit
 ```
 
-The workflow reads direct `*.osi.yaml` files from `osi-dir`. With the default
-input, place OSI files here:
+`osi-dir` is required — set it to the directory that contains your `*.osi.yaml`
+files. The example uses `osi`; change it to match your repository. With
+`osi-dir: osi`, place OSI files here:
 
 ```text
 osi/*.osi.yaml


### PR DESCRIPTION
## What

Makes the source directory inputs **required** and **removes their defaults** across all three connectors:

| Input | Was | Now |
|---|---|---|
| `dbt-project-dir` | `required: false`, `default: dbt_project` | `required: true` |
| `lookml-dir` | `required: false`, `default: lookml` | `required: true` |
| `osi-dir` | `required: false`, `default: osi` | `required: true` |

Applied to both layers for each source: the reusable workflow (`.github/workflows/agents-schema-*.yml`) and the composite action (`.github/actions/agents-schema-*/action.yml`).

The other dbt inputs (`dbt-profile-name`, `dbt-target`, `dbt-parse-command`) are left optional — they are genuine optional features, not the directory params discussed.

## Why

The directory is, and always was, chosen in the **caller's** workflow `with:` block (e.g. `with: dbt-project-dir: dbt_project`). The `default:` only acted as a silent fallback when that input was omitted — so a user who forgot it, or whose project lived elsewhere, would silently run against `dbt_project` / `lookml` / `osi` and either fail confusingly or ingest the wrong location. Making the input required forces an explicit, correct path and fails fast otherwise.

## Docs

Updated the dbt / Looker / OSI setup guides to state that each `*-dir` is required and should be set to match the caller's repository (this addresses the thread question about telling users to update the YAML to match their directory name). Fixed the now-stale "With the default input" wording in `osi-setup.md`.

## Compatibility

No documented usage breaks — every example workflow (`examples/workflows/*.yml`) and every setup guide already passes the directory explicitly in its `with:` block. All six edited YAML files were validated to parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)