### PR TITLE
docs: add 'Query with an agent' setup steps to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,34 +79,37 @@ and [examples/workflows/dbt-looker-osi.yml](examples/workflows/dbt-looker-osi.ym
 Once `AGENTS` is populated, an AI coding agent can answer business questions against your
 warehouse — grounding each answer in your governed metric definitions instead of guessing. The
 [`agents-schema-analyst`](examples/skills/agents-schema-analyst/SKILL.md) skill does this for
-Claude Code and Codex through the Snowflake CLI. It is read-only and carries no business logic;
-it discovers metrics, tables, and rules from `AGENTS.*` at query time, so it works for any
-warehouse that follows this spec.
+Claude Code and Codex through the Snowflake CLI. It is read-only and discovers metrics, tables,
+and rules from `AGENTS.*` at query time, so it works for any warehouse that follows this spec.
 
-**Set it up once:**
+**1. Give the Snowflake CLI a connection.** The skill runs read-only `snow sql`. If you already
+have a `snow` connection (from dbt, another tool, or a prior setup), use it. Otherwise add one
+once:
 
-1. Install the Snowflake CLI and add a read-only connection to your warehouse:
+```bash
+uv tool install snowflake-cli      # if `snow` isn't installed
+snow connection add                # store a read-only connection, e.g. "agents"
+```
 
-   ```bash
-   uv tool install snowflake-cli
-   snow connection add        # name it, e.g. "agents"
-   ```
+**2. Add the skill.** Drop the folder where your agent looks for skills — it is picked up
+automatically, with no install or restart:
 
-2. Copy the skill into your agent's skills directory:
+```bash
+cp -r examples/skills/agents-schema-analyst ~/.claude/skills/   # personal (Codex: ~/.codex/skills/)
+```
 
-   ```bash
-   cp -r examples/skills/agents-schema-analyst ~/.claude/skills/   # Claude Code
-   # or ~/.codex/skills/ for Codex
-   ```
+To share it with your team, commit it to your repo's `.claude/skills/` instead — anyone running
+the agent in that repo gets it on `git pull`.
 
-3. *(Optional)* In your repo's `agents.yml`, point the skill at your connection and schema:
+**3. (Optional) Point the skill at your connection** in your repo's `agents.yml`; otherwise it
+uses your default `snow` connection and the `AGENTS` schema:
 
-   ```yaml
-   snow_cli_connection: agents     # defaults to your default snow connection
-   agents_schema_name: agents      # defaults to AGENTS
-   ```
+```yaml
+snow_cli_connection: agents
+agents_schema_name: agents
+```
 
-**Ask a question:**
+**4. Ask:**
 
 ```text
 /agents-schema-analyst What is our total MRR this month?      # Claude Code

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ available before writing or explaining queries.
   - [Sync Looker](#sync-looker)
   - [Sync OSI](#sync-osi)
   - [Sync Multiple Sources](#sync-multiple-sources)
+- [Query with an agent](#query-with-an-agent)
 - [Why Agents Schema](#why-agents-schema)
   - [How it works](#how-it-works)
 - [Reference](#reference)
@@ -72,6 +73,48 @@ Interchange `*.osi.yaml` files.
 Use the reusable workflows together when one repository contains multiple
 metadata sources. See [examples/workflows/dbt-looker.yml](examples/workflows/dbt-looker.yml)
 and [examples/workflows/dbt-looker-osi.yml](examples/workflows/dbt-looker-osi.yml).
+
+## Query with an agent
+
+Once `AGENTS` is populated, an AI coding agent can answer business questions against your
+warehouse — grounding each answer in your governed metric definitions instead of guessing. The
+[`agents-schema-analyst`](examples/skills/agents-schema-analyst/SKILL.md) skill does this for
+Claude Code and Codex through the Snowflake CLI. It is read-only and carries no business logic;
+it discovers metrics, tables, and rules from `AGENTS.*` at query time, so it works for any
+warehouse that follows this spec.
+
+**Set it up once:**
+
+1. Install the Snowflake CLI and add a read-only connection to your warehouse:
+
+   ```bash
+   uv tool install snowflake-cli
+   snow connection add        # name it, e.g. "agents"
+   ```
+
+2. Copy the skill into your agent's skills directory:
+
+   ```bash
+   cp -r examples/skills/agents-schema-analyst ~/.claude/skills/   # Claude Code
+   # or ~/.codex/skills/ for Codex
+   ```
+
+3. *(Optional)* In your repo's `agents.yml`, point the skill at your connection and schema:
+
+   ```yaml
+   snow_cli_connection: agents     # defaults to your default snow connection
+   agents_schema_name: agents      # defaults to AGENTS
+   ```
+
+**Ask a question:**
+
+```text
+/agents-schema-analyst What is our total MRR this month?      # Claude Code
+$agents-schema-analyst What is our total MRR this month?      # Codex
+```
+
+The agent reads `AGENTS.*` for the right metric definition and source table, then runs a
+read-only query and returns the answer.
 
 ## Why Agents Schema
 

--- a/README.md
+++ b/README.md
@@ -76,48 +76,43 @@ and [examples/workflows/dbt-looker-osi.yml](examples/workflows/dbt-looker-osi.ym
 
 ## Query with an agent
 
-Once `AGENTS` is populated, an AI coding agent can answer business questions against your
-warehouse — grounding each answer in your governed metric definitions instead of guessing. The
+Once `AGENTS` is populated, an AI agent can answer business questions against your warehouse —
+grounded in your real metric definitions instead of guessing. The
 [`agents-schema-analyst`](examples/skills/agents-schema-analyst/SKILL.md) skill does this for
-Claude Code and Codex through the Snowflake CLI. It is read-only and discovers metrics, tables,
-and rules from `AGENTS.*` at query time, so it works for any warehouse that follows this spec.
+Claude Code and Codex: it reads the definitions from `AGENTS.*`, then runs a read-only query. It
+hard-codes nothing, so it works on any warehouse that follows this spec.
 
-**1. Give the Snowflake CLI a connection.** The skill runs read-only `snow sql`. If you already
-have a `snow` connection (from dbt, another tool, or a prior setup), use it. Otherwise add one
-once:
-
-```bash
-uv tool install snowflake-cli      # if `snow` isn't installed
-snow connection add                # store a read-only connection, e.g. "agents"
-```
-
-**2. Add the skill.** Drop the folder where your agent looks for skills — it is picked up
-automatically, with no install or restart:
+**1. Use a Snowflake CLI connection.** The skill queries Snowflake with `snow sql`. Use a
+connection you already have, or create one:
 
 ```bash
-cp -r examples/skills/agents-schema-analyst ~/.claude/skills/   # personal (Codex: ~/.codex/skills/)
+uv tool install snowflake-cli   # if the snow CLI isn't installed
+snow connection add             # skip if you already have a connection
 ```
 
-To share it with your team, commit it to your repo's `.claude/skills/` instead — anyone running
-the agent in that repo gets it on `git pull`.
+**2. Add the skill.** Copy it into your skills folder — it is picked up automatically, no install
+or restart:
 
-**3. (Optional) Point the skill at your connection** in your repo's `agents.yml`; otherwise it
-uses your default `snow` connection and the `AGENTS` schema:
+```bash
+cp -r examples/skills/agents-schema-analyst ~/.claude/skills/   # Codex: ~/.codex/skills/
+```
+
+Working in a shared repo? Commit it to that repo's `.claude/skills/` so your whole team gets it.
+
+**3. (Optional) Tell the skill which connection to use** in your repo's `agents.yml`. Without it,
+the skill uses your default `snow` connection and the `AGENTS` schema:
 
 ```yaml
 snow_cli_connection: agents
 agents_schema_name: agents
 ```
 
-**4. Ask:**
+**4. Ask a question:**
 
 ```text
 /agents-schema-analyst What is our total MRR this month?      # Claude Code
 $agents-schema-analyst What is our total MRR this month?      # Codex
 ```
-
-The agent reads `AGENTS.*` for the right metric definition and source table, then runs a
-read-only query and returns the answer.
 
 ## Why Agents Schema
 

--- a/README.md
+++ b/README.md
@@ -76,43 +76,17 @@ and [examples/workflows/dbt-looker-osi.yml](examples/workflows/dbt-looker-osi.ym
 
 ## Query with an agent
 
-Once `AGENTS` is populated, an AI agent can answer business questions against your warehouse —
-grounded in your real metric definitions instead of guessing. The
-[`agents-schema-analyst`](examples/skills/agents-schema-analyst/SKILL.md) skill does this for
-Claude Code and Codex: it reads the definitions from `AGENTS.*`, then runs a read-only query. It
-hard-codes nothing, so it works on any warehouse that follows this spec.
+Once `AGENTS` is populated, an AI agent can answer questions about your warehouse — grounded in
+your real metric definitions, not guesses. The
+[`agents-schema-analyst`](examples/skills/agents-schema-analyst/SKILL.md) skill reads those
+definitions from `AGENTS.*`, then runs a read-only query, in Claude Code or Codex.
 
-**1. Use a Snowflake CLI connection.** The skill queries Snowflake with `snow sql`. Use a
-connection you already have, or create one:
-
-```bash
-uv tool install snowflake-cli   # if the snow CLI isn't installed
-snow connection add             # skip if you already have a connection
-```
-
-**2. Add the skill.** Copy it into your skills folder — it is picked up automatically, no install
-or restart:
-
-```bash
-cp -r examples/skills/agents-schema-analyst ~/.claude/skills/   # Codex: ~/.codex/skills/
-```
-
-Working in a shared repo? Commit it to that repo's `.claude/skills/` so your whole team gets it.
-
-**3. (Optional) Tell the skill which connection to use** in your repo's `agents.yml`. Without it,
-the skill uses your default `snow` connection and the `AGENTS` schema:
-
-```yaml
-snow_cli_connection: agents
-agents_schema_name: agents
-```
-
-**4. Ask a question:**
-
-```text
-/agents-schema-analyst What is our total MRR this month?      # Claude Code
-$agents-schema-analyst What is our total MRR this month?      # Codex
-```
+1. **Connect to Snowflake** — use an existing `snow` CLI connection, or create one with
+   `snow connection add`.
+2. **Add the skill** — `cp -r examples/skills/agents-schema-analyst ~/.claude/skills/`
+   (Codex: `~/.codex/skills/`).
+3. **Ask** — `/agents-schema-analyst What is our total MRR this month?`
+   (Codex: `$agents-schema-analyst …`).
 
 ## Why Agents Schema
 

--- a/README.md
+++ b/README.md
@@ -76,17 +76,26 @@ and [examples/workflows/dbt-looker-osi.yml](examples/workflows/dbt-looker-osi.ym
 
 ## Query with an agent
 
-Once `AGENTS` is populated, an AI agent can answer questions about your warehouse — grounded in
-your real metric definitions, not guesses. The
-[`agents-schema-analyst`](examples/skills/agents-schema-analyst/SKILL.md) skill reads those
-definitions from `AGENTS.*`, then runs a read-only query, in Claude Code or Codex.
+Once `AGENTS` is populated, the
+[`agents-schema-analyst`](examples/skills/agents-schema-analyst/SKILL.md) skill lets an AI agent
+answer questions about your warehouse — grounded in your real metric definitions from `AGENTS.*`,
+not guesses. You need a `snow` CLI connection (run `snow connection add` if you don't have one).
 
-1. **Connect to Snowflake** — use an existing `snow` CLI connection, or create one with
-   `snow connection add`.
-2. **Add the skill** — `cp -r examples/skills/agents-schema-analyst ~/.claude/skills/`
-   (Codex: `~/.codex/skills/`).
-3. **Ask** — `/agents-schema-analyst What is our total MRR this month?`
-   (Codex: `$agents-schema-analyst …`).
+**Claude Code**
+
+```bash
+cp -r examples/skills/agents-schema-analyst ~/.claude/skills/
+```
+
+Then ask: `/agents-schema-analyst "What is our total MRR this month?"`
+
+**Codex**
+
+```bash
+cp -r examples/skills/agents-schema-analyst ~/.codex/skills/
+```
+
+Then ask: `$agents-schema-analyst "What is our total MRR this month?"`
 
 ## Why Agents Schema
 


### PR DESCRIPTION
## What

Adds a concise **Query with an agent** section to the README (with a TOC entry), documenting how to set up and use the `agents-schema-analyst` skill: install the Snowflake CLI, add a read-only connection, copy the skill into the agent's skills dir, optionally configure `agents.yml`, then ask a question.

It sits right after the **Guides** (populate `AGENTS`) and before **Why Agents Schema** — the natural "now use it" step.

## Depends on #8

The section links to `examples/skills/agents-schema-analyst/SKILL.md`, which is added in #8. **Merge #8 first** (or merge this after) so the link resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)