### PR TITLE
docs: install skill via curl instead of cp from a clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ not guesses. You need a `snow` CLI connection (run `snow connection add` if you 
 **Claude Code**
 
 ```bash
-mkdir -p ~/.claude/skills/agents-schema-analyst
-curl -fsSL https://raw.githubusercontent.com/fivetran/agents_schema/main/examples/skills/agents-schema-analyst/SKILL.md \
-  -o ~/.claude/skills/agents-schema-analyst/SKILL.md
+curl -fsSL --create-dirs \
+  -o ~/.claude/skills/agents-schema-analyst/SKILL.md \
+  https://raw.githubusercontent.com/fivetran/agents_schema/main/examples/skills/agents-schema-analyst/SKILL.md
 ```
 
 Then ask: `/agents-schema-analyst "What is our total MRR this month?"`
@@ -94,9 +94,9 @@ Then ask: `/agents-schema-analyst "What is our total MRR this month?"`
 **Codex**
 
 ```bash
-mkdir -p ~/.codex/skills/agents-schema-analyst
-curl -fsSL https://raw.githubusercontent.com/fivetran/agents_schema/main/examples/skills/agents-schema-analyst/SKILL.md \
-  -o ~/.codex/skills/agents-schema-analyst/SKILL.md
+curl -fsSL --create-dirs \
+  -o ~/.codex/skills/agents-schema-analyst/SKILL.md \
+  https://raw.githubusercontent.com/fivetran/agents_schema/main/examples/skills/agents-schema-analyst/SKILL.md
 ```
 
 Then ask: `$agents-schema-analyst "What is our total MRR this month?"`

--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ not guesses. You need a `snow` CLI connection (run `snow connection add` if you 
 **Claude Code**
 
 ```bash
-cp -r examples/skills/agents-schema-analyst ~/.claude/skills/
+mkdir -p ~/.claude/skills/agents-schema-analyst
+curl -fsSL https://raw.githubusercontent.com/fivetran/agents_schema/main/examples/skills/agents-schema-analyst/SKILL.md \
+  -o ~/.claude/skills/agents-schema-analyst/SKILL.md
 ```
 
 Then ask: `/agents-schema-analyst "What is our total MRR this month?"`
@@ -92,7 +94,9 @@ Then ask: `/agents-schema-analyst "What is our total MRR this month?"`
 **Codex**
 
 ```bash
-cp -r examples/skills/agents-schema-analyst ~/.codex/skills/
+mkdir -p ~/.codex/skills/agents-schema-analyst
+curl -fsSL https://raw.githubusercontent.com/fivetran/agents_schema/main/examples/skills/agents-schema-analyst/SKILL.md \
+  -o ~/.codex/skills/agents-schema-analyst/SKILL.md
 ```
 
 Then ask: `$agents-schema-analyst "What is our total MRR this month?"`

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ not guesses. You need a `snow` CLI connection (run `snow connection add` if you 
 ```bash
 curl -fsSL --create-dirs \
   -o ~/.claude/skills/agents-schema-analyst/SKILL.md \
-  https://raw.githubusercontent.com/fivetran/agents_schema/main/examples/skills/agents-schema-analyst/SKILL.md
+  https://raw.githubusercontent.com/fivetran/agents_schema/v0.0.5/examples/skills/agents-schema-analyst/SKILL.md
 ```
 
 Then ask: `/agents-schema-analyst "What is our total MRR this month?"`
@@ -96,7 +96,7 @@ Then ask: `/agents-schema-analyst "What is our total MRR this month?"`
 ```bash
 curl -fsSL --create-dirs \
   -o ~/.codex/skills/agents-schema-analyst/SKILL.md \
-  https://raw.githubusercontent.com/fivetran/agents_schema/main/examples/skills/agents-schema-analyst/SKILL.md
+  https://raw.githubusercontent.com/fivetran/agents_schema/v0.0.5/examples/skills/agents-schema-analyst/SKILL.md
 ```
 
 Then ask: `$agents-schema-analyst "What is our total MRR this month?"`


### PR DESCRIPTION
## Problem

The README's install step was `cp -r examples/skills/agents-schema-analyst ~/.claude/skills/`, which only works if you're standing in a **clone** of this repo. But agents_schema is distributed via `uvx`/PyPI — customers never clone it, so they have no `examples/` directory and the command silently fails.

## Fix

Download `SKILL.md` straight from GitHub into the skills directory — no clone required:

```bash
mkdir -p ~/.claude/skills/agents-schema-analyst
curl -fsSL https://raw.githubusercontent.com/fivetran/agents_schema/main/examples/skills/agents-schema-analyst/SKILL.md \
  -o ~/.claude/skills/agents-schema-analyst/SKILL.md
```

(and the `~/.codex/skills/` equivalent for Codex). `examples/` stays the single source of truth.

Verified the raw URL resolves to the current skill on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)