### PR TITLE
Add example notes_on provider

### DIFF
--- a/examples/providers/README.md
+++ b/examples/providers/README.md
@@ -1,0 +1,15 @@
+# Example Providers
+
+This directory contains optional provider examples for Agents Schema.
+
+Example providers are not part of the core Agents Schema contract. They show how
+a team can use the extension model:
+
+- choose a provider name
+- isolate provider-owned tables with that prefix
+- optionally publish provider-authored rows into `AGENTS.ROOT`
+- keep implementation-specific opinions outside the core package
+
+An example provider can later move to its own repository/package or be promoted
+into the core project if the community agrees it should become a standard
+provider.

--- a/examples/providers/notes_on/README.md
+++ b/examples/providers/notes_on/README.md
@@ -1,0 +1,79 @@
+# Notes On Provider
+
+`notes_on` is an optional Agents Schema provider for durable notes attached to
+warehouse schemas, tables, and columns. Teams can add it when this note layer is
+useful for their agents, catalogs, review workflows, or analytics tooling.
+
+It is not a core provider and does not require everyone adopting Agents Schema
+to adopt this note shape. The package does not modify the core `agents-schema`
+CLI, core `ROOT_ENTRIES`, or core `SPEC.md`; it publishes its own prefixed
+tables and registers provider-authored metadata in `AGENTS.ROOT`.
+
+## Tables
+
+The provider writes:
+
+- `AGENTS.NOTES_ON_SCHEMATA`
+- `AGENTS.NOTES_ON_TABLES`
+- `AGENTS.NOTES_ON_COLUMNS`
+
+It also upserts provider-authored root rows:
+
+- `(notes_on, overview)`
+- `(notes_on, schemata)`
+- `(notes_on, tables)`
+- `(notes_on, columns)`
+
+## Install And Run
+
+From this directory:
+
+```bash
+uv run agents-schema-notes-on --notes-file notes.yml
+```
+
+The command reads Snowflake credentials from `WAREHOUSE_CREDENTIALS`, using the
+same YAML/JSON shape as the core package.
+
+The command replaces the three `AGENTS.NOTES_ON_*` tables and upserts the
+provider's own `AGENTS.ROOT` rows. That root write is provider-owned metadata,
+not a change to the core provider registry.
+
+## Source File
+
+See [notes.yml](notes.yml) for a complete example.
+
+```yaml
+column_notes:
+  - note_id: stripe_invoice_amount_due_cents
+    table_schema: stripe
+    table_name: invoice
+    column_name: amount_due
+    kind: unit_rule
+    tags: [stripe, money]
+    content: Stripe amount columns are stored in cents; divide by 100 for dollar measures.
+    author: analyst@example.com
+    confidence: 0.9
+    importance: 1.0
+```
+
+## Context Views
+
+The source tables are one row per note, not one row per database object. A
+generic `AGENTS.SCHEMATA`, `AGENTS.TABLES`, or `AGENTS.COLUMNS` enrichment
+should aggregate them before joining. See
+[sql/context_views.sql](sql/context_views.sql) for one possible aggregation
+shape using a `VARIANT` array of note objects.
+
+## Optional Fields
+
+`kind` is required so consumers can filter broad categories such as
+`unit_rule`, `grain_warning`, or `time_policy`.
+
+`tags` is optional and deliberately loose. It is useful for lightweight facets
+like `finance`, `pii`, or `agent_generated`, but this example does not require a
+shared taxonomy.
+
+`confidence` and `importance` are optional floats in `[0, 1]`. Use `confidence`
+for trust in the note and `importance` for retrieval salience when prompt budget
+is limited.

--- a/examples/providers/notes_on/SPEC.md
+++ b/examples/providers/notes_on/SPEC.md
@@ -1,0 +1,107 @@
+# Notes On Provider Spec
+
+`notes_on` is an optional provider for teams that want a durable note layer on
+warehouse schemas, tables, and columns. It is not part of the core Agents Schema
+spec and does not require other providers or consumers to adopt this shape.
+
+## Provider Rows
+
+```text
+provider  key       content
+notes_on  overview  Portable, object-scoped annotations for warehouse schemas, tables, and columns.
+notes_on  schemata  One row per note attached to a warehouse schema. See AGENTS.NOTES_ON_SCHEMATA.
+notes_on  tables    One row per note attached to a warehouse table. See AGENTS.NOTES_ON_TABLES.
+notes_on  columns   One row per note attached to a warehouse column. See AGENTS.NOTES_ON_COLUMNS.
+```
+
+## Tables
+
+```sql
+CREATE OR REPLACE TABLE AGENTS.NOTES_ON_SCHEMATA (
+  note_id     VARCHAR NOT NULL,
+  schema_name VARCHAR NOT NULL,
+  kind        VARCHAR NOT NULL,
+  tags        VARIANT,
+  title       VARCHAR,
+  content     TEXT NOT NULL,
+  author      VARCHAR,
+  source      VARCHAR,
+  confidence  FLOAT,
+  importance  FLOAT,
+  created_at  TIMESTAMP,
+  updated_at  TIMESTAMP,
+  PRIMARY KEY (note_id)
+);
+
+CREATE OR REPLACE TABLE AGENTS.NOTES_ON_TABLES (
+  note_id       VARCHAR NOT NULL,
+  table_catalog VARCHAR,
+  table_schema  VARCHAR NOT NULL,
+  table_name    VARCHAR NOT NULL,
+  kind          VARCHAR NOT NULL,
+  tags          VARIANT,
+  title         VARCHAR,
+  content       TEXT NOT NULL,
+  author        VARCHAR,
+  source        VARCHAR,
+  confidence    FLOAT,
+  importance    FLOAT,
+  created_at    TIMESTAMP,
+  updated_at    TIMESTAMP,
+  PRIMARY KEY (note_id)
+);
+
+CREATE OR REPLACE TABLE AGENTS.NOTES_ON_COLUMNS (
+  note_id       VARCHAR NOT NULL,
+  table_catalog VARCHAR,
+  table_schema  VARCHAR NOT NULL,
+  table_name    VARCHAR NOT NULL,
+  column_name   VARCHAR NOT NULL,
+  kind          VARCHAR NOT NULL,
+  tags          VARIANT,
+  title         VARCHAR,
+  content       TEXT NOT NULL,
+  author        VARCHAR,
+  source        VARCHAR,
+  confidence    FLOAT,
+  importance    FLOAT,
+  created_at    TIMESTAMP,
+  updated_at    TIMESTAMP,
+  PRIMARY KEY (note_id)
+);
+```
+
+## Required Fields
+
+Every note requires `note_id`, `kind`, and `content`.
+
+Schema notes also require `schema_name`. Table notes require `table_schema` and
+`table_name`. Column notes require `table_schema`, `table_name`, and
+`column_name`.
+
+`table_catalog` is optional because many local metadata systems identify tables
+within one active database. Providers that can populate it should do so.
+
+## Kind
+
+`kind` is a required string that lets consumers filter broad categories without
+parsing note text. Examples include `unit_rule`, `grain_warning`, `time_policy`,
+`join_warning`, `pii`, and `business_definition`.
+
+## Scores
+
+`confidence` is an optional trust score in `[0, 1]`.
+
+`importance` is an optional retrieval salience score in `[0, 1]`.
+
+## Tags
+
+`tags` is an optional array of strings. It is intended for loose facets such as
+`finance`, `pii`, `unit`, or `agent_generated`, not a required taxonomy.
+
+## Context Aggregation
+
+These tables are one row per note. Context views that expose one row per schema,
+table, or column should aggregate notes into an array rather than concatenate
+text. The example implementation publishes `notes_on_notes` as an array of note
+objects alongside `notes_on_count` and `notes_on_highest_importance`.

--- a/examples/providers/notes_on/notes.yml
+++ b/examples/providers/notes_on/notes.yml
@@ -1,0 +1,37 @@
+schema_notes:
+  - note_id: sales_schema_time_policy
+    schema_name: sales
+    kind: time_policy
+    tags: [finance, revenue]
+    title: Sales reporting time
+    content: Sales reporting should use closed_at unless the question asks about pipeline creation.
+    author: revenue-ops
+    source: notes.yml
+    confidence: 0.95
+    importance: 0.8
+    created_at: "2026-06-01T12:00:00Z"
+
+table_notes:
+  - note_id: zendesk_ticket_grain
+    table_schema: zendesk
+    table_name: ticket
+    kind: grain_warning
+    tags: [support, grain]
+    title: Ticket grain
+    content: One row is one current ticket. Event-level analysis should use ticket_event and collapse before joining back.
+    author: data-platform
+    source: catalog://zendesk/ticket
+
+column_notes:
+  - note_id: stripe_invoice_amount_due_cents
+    table_schema: stripe
+    table_name: invoice
+    column_name: amount_due
+    kind: unit_rule
+    tags: [stripe, money]
+    title: Stripe amount units
+    content: Stripe amount columns are stored in cents; divide by 100 for dollar measures.
+    author: analyst@example.com
+    source: dbt://model/stripe_invoice
+    confidence: 0.9
+    importance: 1.0

--- a/examples/providers/notes_on/pyproject.toml
+++ b/examples/providers/notes_on/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "agents-schema-notes-on"
+version = "0.0.0"
+description = "Example Agents Schema provider for object-scoped notes."
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "cryptography>=3.1.0",
+    "pyyaml>=6.0",
+    "snowflake-connector-python>=3.0.0",
+]
+
+[project.scripts]
+agents-schema-notes-on = "agents_schema_notes_on.cli:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/agents_schema_notes_on"]

--- a/examples/providers/notes_on/sql/context_views.sql
+++ b/examples/providers/notes_on/sql/context_views.sql
@@ -1,0 +1,73 @@
+CREATE OR REPLACE VIEW AGENTS.NOTES_ON_SCHEMATA_CONTEXT AS
+SELECT
+  schema_name,
+  COUNT(*) AS notes_on_count,
+  MAX(importance) AS notes_on_highest_importance,
+  ARRAY_AGG(
+    OBJECT_CONSTRUCT_KEEP_NULL(
+      'note_id', note_id,
+      'kind', kind,
+      'tags', tags,
+      'title', title,
+      'content', content,
+      'author', author,
+      'source', source,
+      'confidence', confidence,
+      'importance', importance,
+      'created_at', created_at,
+      'updated_at', updated_at
+    )
+  ) AS notes_on_notes
+FROM AGENTS.NOTES_ON_SCHEMATA
+GROUP BY schema_name;
+
+CREATE OR REPLACE VIEW AGENTS.NOTES_ON_TABLES_CONTEXT AS
+SELECT
+  table_catalog,
+  table_schema,
+  table_name,
+  COUNT(*) AS notes_on_count,
+  MAX(importance) AS notes_on_highest_importance,
+  ARRAY_AGG(
+    OBJECT_CONSTRUCT_KEEP_NULL(
+      'note_id', note_id,
+      'kind', kind,
+      'tags', tags,
+      'title', title,
+      'content', content,
+      'author', author,
+      'source', source,
+      'confidence', confidence,
+      'importance', importance,
+      'created_at', created_at,
+      'updated_at', updated_at
+    )
+  ) AS notes_on_notes
+FROM AGENTS.NOTES_ON_TABLES
+GROUP BY table_catalog, table_schema, table_name;
+
+CREATE OR REPLACE VIEW AGENTS.NOTES_ON_COLUMNS_CONTEXT AS
+SELECT
+  table_catalog,
+  table_schema,
+  table_name,
+  column_name,
+  COUNT(*) AS notes_on_count,
+  MAX(importance) AS notes_on_highest_importance,
+  ARRAY_AGG(
+    OBJECT_CONSTRUCT_KEEP_NULL(
+      'note_id', note_id,
+      'kind', kind,
+      'tags', tags,
+      'title', title,
+      'content', content,
+      'author', author,
+      'source', source,
+      'confidence', confidence,
+      'importance', importance,
+      'created_at', created_at,
+      'updated_at', updated_at
+    )
+  ) AS notes_on_notes
+FROM AGENTS.NOTES_ON_COLUMNS
+GROUP BY table_catalog, table_schema, table_name, column_name;

--- a/examples/providers/notes_on/sql/root_entries.sql
+++ b/examples/providers/notes_on/sql/root_entries.sql
@@ -1,0 +1,27 @@
+CREATE SCHEMA IF NOT EXISTS AGENTS;
+
+CREATE TABLE IF NOT EXISTS AGENTS.ROOT (
+  provider VARCHAR NOT NULL,
+  key      VARCHAR NOT NULL,
+  content  TEXT NOT NULL,
+  PRIMARY KEY (provider, key)
+);
+
+MERGE INTO AGENTS.ROOT AS target
+USING (
+  SELECT 'notes_on' AS provider, 'overview' AS key,
+         '# Notes On\nPortable, object-scoped annotations for warehouse schemas, tables, and columns.' AS content
+  UNION ALL
+  SELECT 'notes_on', 'schemata',
+         'One row per note attached to a warehouse schema. See AGENTS.NOTES_ON_SCHEMATA.'
+  UNION ALL
+  SELECT 'notes_on', 'tables',
+         'One row per note attached to a warehouse table. See AGENTS.NOTES_ON_TABLES.'
+  UNION ALL
+  SELECT 'notes_on', 'columns',
+         'One row per note attached to a warehouse column. See AGENTS.NOTES_ON_COLUMNS.'
+) AS source
+ON target.provider = source.provider AND target.key = source.key
+WHEN MATCHED THEN UPDATE SET target.content = source.content
+WHEN NOT MATCHED THEN INSERT (provider, key, content)
+VALUES (source.provider, source.key, source.content);

--- a/examples/providers/notes_on/sql/tables.sql
+++ b/examples/providers/notes_on/sql/tables.sql
@@ -1,0 +1,54 @@
+CREATE SCHEMA IF NOT EXISTS AGENTS;
+
+CREATE OR REPLACE TABLE AGENTS.NOTES_ON_SCHEMATA (
+  note_id     VARCHAR NOT NULL,
+  schema_name VARCHAR NOT NULL,
+  kind        VARCHAR NOT NULL,
+  tags        VARIANT,
+  title       VARCHAR,
+  content     TEXT NOT NULL,
+  author      VARCHAR,
+  source      VARCHAR,
+  confidence  FLOAT,
+  importance  FLOAT,
+  created_at  TIMESTAMP,
+  updated_at  TIMESTAMP,
+  PRIMARY KEY (note_id)
+);
+
+CREATE OR REPLACE TABLE AGENTS.NOTES_ON_TABLES (
+  note_id       VARCHAR NOT NULL,
+  table_catalog VARCHAR,
+  table_schema  VARCHAR NOT NULL,
+  table_name    VARCHAR NOT NULL,
+  kind          VARCHAR NOT NULL,
+  tags          VARIANT,
+  title         VARCHAR,
+  content       TEXT NOT NULL,
+  author        VARCHAR,
+  source        VARCHAR,
+  confidence    FLOAT,
+  importance    FLOAT,
+  created_at    TIMESTAMP,
+  updated_at    TIMESTAMP,
+  PRIMARY KEY (note_id)
+);
+
+CREATE OR REPLACE TABLE AGENTS.NOTES_ON_COLUMNS (
+  note_id       VARCHAR NOT NULL,
+  table_catalog VARCHAR,
+  table_schema  VARCHAR NOT NULL,
+  table_name    VARCHAR NOT NULL,
+  column_name   VARCHAR NOT NULL,
+  kind          VARCHAR NOT NULL,
+  tags          VARIANT,
+  title         VARCHAR,
+  content       TEXT NOT NULL,
+  author        VARCHAR,
+  source        VARCHAR,
+  confidence    FLOAT,
+  importance    FLOAT,
+  created_at    TIMESTAMP,
+  updated_at    TIMESTAMP,
+  PRIMARY KEY (note_id)
+);

--- a/examples/providers/notes_on/src/agents_schema_notes_on/__init__.py
+++ b/examples/providers/notes_on/src/agents_schema_notes_on/__init__.py
@@ -1,0 +1,5 @@
+"""Example notes_on provider for Agents Schema."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.0.0"

--- a/examples/providers/notes_on/src/agents_schema_notes_on/cli.py
+++ b/examples/providers/notes_on/src/agents_schema_notes_on/cli.py
@@ -1,0 +1,34 @@
+"""Command-line interface for the notes_on example provider."""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from . import __version__
+from .provider import NotesOnError, run
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="agents-schema-notes-on",
+        description="Publish object-scoped notes into AGENTS.NOTES_ON_* tables.",
+    )
+    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
+    parser.add_argument(
+        "--notes-file",
+        required=True,
+        type=Path,
+        help="path to a YAML file containing schema, table, and column notes",
+    )
+    args = parser.parse_args(argv)
+    try:
+        run(args.notes_file)
+    except (FileNotFoundError, NotesOnError) as e:
+        print(f"agents-schema-notes-on: error: {e}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/providers/notes_on/src/agents_schema_notes_on/provider.py
+++ b/examples/providers/notes_on/src/agents_schema_notes_on/provider.py
@@ -1,0 +1,500 @@
+"""Implementation for the notes_on example provider."""
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any, Iterable
+
+import yaml
+
+AGENTS_SCHEMA = "agents"
+INSERT_BATCH_SIZE = 1000
+IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_$]*$")
+
+
+class NotesOnError(Exception):
+    """Raised for user-facing provider configuration and validation errors."""
+
+
+@dataclass(frozen=True)
+class Column:
+    name: str
+    kind: str
+    nullable: bool = True
+
+
+@dataclass(frozen=True)
+class Table:
+    name: str
+    columns: tuple[Column, ...]
+    primary_key: tuple[str, ...] = ()
+
+    @property
+    def variant_indexes(self) -> set[int]:
+        return {i for i, column in enumerate(self.columns) if column.kind == "variant"}
+
+
+ROOT = Table(
+    "root",
+    (
+        Column("provider", "varchar", nullable=False),
+        Column("key", "varchar", nullable=False),
+        Column("content", "text", nullable=False),
+    ),
+    primary_key=("provider", "key"),
+)
+
+NOTES_ON_SCHEMATA = Table(
+    "notes_on_schemata",
+    (
+        Column("note_id", "varchar", nullable=False),
+        Column("schema_name", "varchar", nullable=False),
+        Column("kind", "varchar", nullable=False),
+        Column("tags", "variant"),
+        Column("title", "varchar"),
+        Column("content", "text", nullable=False),
+        Column("author", "varchar"),
+        Column("source", "varchar"),
+        Column("confidence", "float"),
+        Column("importance", "float"),
+        Column("created_at", "timestamp"),
+        Column("updated_at", "timestamp"),
+    ),
+    primary_key=("note_id",),
+)
+
+NOTES_ON_TABLES = Table(
+    "notes_on_tables",
+    (
+        Column("note_id", "varchar", nullable=False),
+        Column("table_catalog", "varchar"),
+        Column("table_schema", "varchar", nullable=False),
+        Column("table_name", "varchar", nullable=False),
+        Column("kind", "varchar", nullable=False),
+        Column("tags", "variant"),
+        Column("title", "varchar"),
+        Column("content", "text", nullable=False),
+        Column("author", "varchar"),
+        Column("source", "varchar"),
+        Column("confidence", "float"),
+        Column("importance", "float"),
+        Column("created_at", "timestamp"),
+        Column("updated_at", "timestamp"),
+    ),
+    primary_key=("note_id",),
+)
+
+NOTES_ON_COLUMNS = Table(
+    "notes_on_columns",
+    (
+        Column("note_id", "varchar", nullable=False),
+        Column("table_catalog", "varchar"),
+        Column("table_schema", "varchar", nullable=False),
+        Column("table_name", "varchar", nullable=False),
+        Column("column_name", "varchar", nullable=False),
+        Column("kind", "varchar", nullable=False),
+        Column("tags", "variant"),
+        Column("title", "varchar"),
+        Column("content", "text", nullable=False),
+        Column("author", "varchar"),
+        Column("source", "varchar"),
+        Column("confidence", "float"),
+        Column("importance", "float"),
+        Column("created_at", "timestamp"),
+        Column("updated_at", "timestamp"),
+    ),
+    primary_key=("note_id",),
+)
+
+ROOT_ROWS = (
+    (
+        "notes_on",
+        "overview",
+        "# Notes On\nPortable, object-scoped annotations for warehouse schemas, tables, and columns.",
+    ),
+    ("notes_on", "schemata", "One row per note attached to a warehouse schema. See AGENTS.NOTES_ON_SCHEMATA."),
+    ("notes_on", "tables", "One row per note attached to a warehouse table. See AGENTS.NOTES_ON_TABLES."),
+    ("notes_on", "columns", "One row per note attached to a warehouse column. See AGENTS.NOTES_ON_COLUMNS."),
+)
+
+COMMON_NOTE_FIELDS = (
+    "note_id",
+    "kind",
+    "tags",
+    "title",
+    "content",
+    "author",
+    "source",
+    "confidence",
+    "importance",
+    "created_at",
+    "updated_at",
+)
+SCHEMA_NOTE_FIELDS = ("note_id", "schema_name", *COMMON_NOTE_FIELDS[1:])
+TABLE_NOTE_FIELDS = ("note_id", "table_catalog", "table_schema", "table_name", *COMMON_NOTE_FIELDS[1:])
+COLUMN_NOTE_FIELDS = (
+    "note_id",
+    "table_catalog",
+    "table_schema",
+    "table_name",
+    "column_name",
+    *COMMON_NOTE_FIELDS[1:],
+)
+TOP_LEVEL_FIELDS = frozenset({"schema_notes", "table_notes", "column_notes"})
+NOTE_SECTIONS = (
+    ("schema_notes", SCHEMA_NOTE_FIELDS, ("schema_name",)),
+    ("table_notes", TABLE_NOTE_FIELDS, ("table_schema", "table_name")),
+    ("column_notes", COLUMN_NOTE_FIELDS, ("table_schema", "table_name", "column_name")),
+)
+NOTE_SCORE_FIELDS = frozenset({"confidence", "importance"})
+NOTE_ARRAY_FIELDS = frozenset({"tags"})
+NOTE_TIMESTAMP_FIELDS = frozenset({"created_at", "updated_at"})
+NOTE_STRING_FIELDS = (
+    frozenset(COMMON_NOTE_FIELDS)
+    - NOTE_SCORE_FIELDS
+    - NOTE_ARRAY_FIELDS
+    - NOTE_TIMESTAMP_FIELDS
+    | {"schema_name", "table_catalog", "table_schema", "table_name", "column_name"}
+)
+
+
+def run(notes_file: Path) -> None:
+    schema_notes, table_notes, column_notes = load_notes_file(notes_file)
+    with SnowflakeDestination.from_env() as dest:
+        dest.upsert_rows(ROOT, ROOT_ROWS)
+        dest.replace_table(NOTES_ON_SCHEMATA)
+        dest.replace_table(NOTES_ON_TABLES)
+        dest.replace_table(NOTES_ON_COLUMNS)
+        if schema_notes:
+            dest.insert_rows(NOTES_ON_SCHEMATA, schema_notes)
+        if table_notes:
+            dest.insert_rows(NOTES_ON_TABLES, table_notes)
+        if column_notes:
+            dest.insert_rows(NOTES_ON_COLUMNS, column_notes)
+    print(
+        "  notes_on: "
+        f"{len(schema_notes)} schema notes, "
+        f"{len(table_notes)} table notes, "
+        f"{len(column_notes)} column notes"
+    )
+
+
+def load_notes_file(path: Path) -> tuple[list[tuple[Any, ...]], list[tuple[Any, ...]], list[tuple[Any, ...]]]:
+    try:
+        data = yaml.safe_load(path.read_text()) or {}
+    except yaml.YAMLError as e:
+        raise NotesOnError(f"notes file is not valid YAML: {e}") from e
+    if not isinstance(data, dict):
+        raise NotesOnError("notes file must be a YAML object")
+    _reject_unknown_fields(data, TOP_LEVEL_FIELDS, "notes file")
+
+    rows_by_section: dict[str, list[tuple[Any, ...]]] = {}
+    seen_note_ids: set[str] = set()
+    for section, fields, required_fields in NOTE_SECTIONS:
+        raw_notes = data.get(section, [])
+        if not isinstance(raw_notes, list):
+            raise NotesOnError(f"{section} must be a list")
+        rows_by_section[section] = _load_note_rows(
+            raw_notes,
+            section,
+            fields,
+            required_fields,
+            seen_note_ids,
+        )
+
+    return (
+        rows_by_section["schema_notes"],
+        rows_by_section["table_notes"],
+        rows_by_section["column_notes"],
+    )
+
+
+def _load_note_rows(
+    raw_notes: list[Any],
+    section: str,
+    fields: tuple[str, ...],
+    required_fields: tuple[str, ...],
+    seen_note_ids: set[str],
+) -> list[tuple[Any, ...]]:
+    rows = []
+    allowed_fields = frozenset(fields)
+    for index, raw_note in enumerate(raw_notes):
+        path = f"{section}[{index}]"
+        if not isinstance(raw_note, dict):
+            raise NotesOnError(f"{path} must be an object")
+        _reject_unknown_fields(raw_note, allowed_fields, path)
+        _validate_strings(raw_note, NOTE_STRING_FIELDS, path)
+        _validate_string_lists(raw_note, NOTE_ARRAY_FIELDS, path)
+        _validate_timestamps(raw_note, NOTE_TIMESTAMP_FIELDS, path)
+        _validate_scores(raw_note, NOTE_SCORE_FIELDS, path)
+        note_id = _required_str(raw_note, "note_id", path)
+        if note_id in seen_note_ids:
+            raise NotesOnError(f"duplicate note_id: {note_id}")
+        seen_note_ids.add(note_id)
+        _required_str(raw_note, "kind", path)
+        _required_str(raw_note, "content", path)
+        for field in required_fields:
+            _required_str(raw_note, field, path)
+        rows.append(tuple(raw_note.get(field) for field in fields))
+    return rows
+
+
+def _required_str(data: dict[str, Any], field: str, path: str) -> str:
+    value = data.get(field)
+    if not isinstance(value, str) or not value:
+        raise NotesOnError(f"{path}.{field} is required")
+    return value
+
+
+def _reject_unknown_fields(data: dict[str, Any], allowed: frozenset[str], path: str) -> None:
+    unknown = sorted(set(data) - allowed)
+    if unknown:
+        raise NotesOnError(f"{path} has unknown field: {unknown[0]}")
+
+
+def _validate_strings(data: dict[str, Any], fields: frozenset[str], path: str) -> None:
+    for field in fields:
+        value = data.get(field)
+        if value is not None and not isinstance(value, str):
+            raise NotesOnError(f"{path}.{field} must be a string")
+
+
+def _validate_string_lists(data: dict[str, Any], fields: frozenset[str], path: str) -> None:
+    for field in fields:
+        value = data.get(field)
+        if value is None:
+            continue
+        if not isinstance(value, list) or not all(isinstance(item, str) and item for item in value):
+            raise NotesOnError(f"{path}.{field} must be a list of strings")
+
+
+def _validate_timestamps(data: dict[str, Any], fields: frozenset[str], path: str) -> None:
+    for field in fields:
+        value = data.get(field)
+        if value is not None and not isinstance(value, (str, date, datetime)):
+            raise NotesOnError(f"{path}.{field} must be a timestamp")
+
+
+def _validate_scores(data: dict[str, Any], fields: frozenset[str], path: str) -> None:
+    for field in fields:
+        value = data.get(field)
+        if value is None:
+            continue
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise NotesOnError(f"{path}.{field} must be a number")
+        if not 0.0 <= float(value) <= 1.0:
+            raise NotesOnError(f"{path}.{field} must be between 0 and 1")
+
+
+class SnowflakeDestination:
+    def __init__(self, config: dict[str, Any]) -> None:
+        import snowflake.connector
+
+        self._con = snowflake.connector.connect(**_snowflake_connect_kwargs(config))
+
+    @classmethod
+    def from_env(cls) -> "SnowflakeDestination":
+        return cls(warehouse_credentials_from_env())
+
+    def __enter__(self) -> "SnowflakeDestination":
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+        self.close()
+
+    def close(self) -> None:
+        self._con.close()
+
+    def replace_table(self, table: Table) -> None:
+        with self._con.cursor() as cur:
+            cur.execute(f"CREATE SCHEMA IF NOT EXISTS {AGENTS_SCHEMA}")
+            cur.execute(_create_table_sql(table))
+
+    def upsert_rows(self, table: Table, rows: Iterable[tuple[Any, ...]]) -> None:
+        bind_rows = _bind_rows(table, rows)
+        if not bind_rows:
+            return
+        with self._con.cursor() as cur:
+            cur.execute(f"CREATE SCHEMA IF NOT EXISTS {AGENTS_SCHEMA}")
+            cur.execute(_create_table_if_not_exists_sql(table))
+            for batch in _batched(bind_rows, INSERT_BATCH_SIZE):
+                cur.execute(_merge_sql(table, len(batch)), _flatten(batch))
+
+    def insert_rows(self, table: Table, rows: Iterable[tuple[Any, ...]]) -> None:
+        bind_rows = _bind_rows(table, rows)
+        if not bind_rows:
+            return
+        with self._con.cursor() as cur:
+            for batch in _batched(bind_rows, INSERT_BATCH_SIZE):
+                cur.execute(_insert_sql(table, len(batch)), _flatten(batch))
+
+
+def warehouse_credentials_from_env() -> dict[str, Any]:
+    raw = os.environ.get("WAREHOUSE_CREDENTIALS")
+    if not raw:
+        raise NotesOnError("missing required WAREHOUSE_CREDENTIALS secret")
+    try:
+        destination = json.loads(raw)
+    except json.JSONDecodeError:
+        try:
+            destination = yaml.safe_load(raw)
+        except yaml.YAMLError as e:
+            raise NotesOnError(f"WAREHOUSE_CREDENTIALS is not valid JSON or YAML: {e}") from e
+    if not isinstance(destination, dict):
+        raise NotesOnError("WAREHOUSE_CREDENTIALS must be a JSON or YAML object")
+    if destination.get("type") != "snowflake":
+        raise NotesOnError("WAREHOUSE_CREDENTIALS.type must be snowflake")
+    return destination
+
+
+def _snowflake_connect_kwargs(destination: dict[str, Any]) -> dict[str, Any]:
+    required = ["account", "user", "warehouse", "database"]
+    missing = [name for name in required if not destination.get(name)]
+    has_password = bool(destination.get("password"))
+    has_private_key_pem = bool(destination.get("private_key_pem"))
+    has_private_key_path = bool(destination.get("private_key_path"))
+    if not has_password and not has_private_key_pem and not has_private_key_path:
+        missing.append("password, private_key_pem, or private_key_path")
+    if missing:
+        raise NotesOnError("WAREHOUSE_CREDENTIALS missing keys: " + ", ".join(missing))
+
+    kwargs: dict[str, Any] = {
+        "account": destination["account"],
+        "user": destination["user"],
+        "warehouse": destination["warehouse"],
+        "database": destination["database"],
+    }
+    if role := destination.get("role"):
+        kwargs["role"] = role
+    passphrase = destination.get("private_key_passphrase")
+    if has_private_key_pem:
+        kwargs["private_key"] = _load_private_key(destination["private_key_pem"].encode(), passphrase)
+    elif has_private_key_path:
+        kwargs["private_key"] = _load_private_key(Path(destination["private_key_path"]).read_bytes(), passphrase)
+    else:
+        kwargs["password"] = destination["password"]
+    return kwargs
+
+
+def _load_private_key(pem_bytes: bytes, passphrase: str | None) -> bytes:
+    from cryptography.hazmat.primitives import serialization
+
+    password = passphrase.encode() if passphrase else None
+    private_key = serialization.load_pem_private_key(pem_bytes, password=password)
+    return private_key.private_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+
+def _bind_rows(table: Table, rows: Iterable[tuple[Any, ...]]) -> list[tuple[Any, ...]]:
+    bind_rows = []
+    for row in rows:
+        bind_row = []
+        for i, value in enumerate(row):
+            if i in table.variant_indexes:
+                bind_row.append(json.dumps(value or []))
+            else:
+                bind_row.append(value)
+        bind_rows.append(tuple(bind_row))
+    return bind_rows
+
+
+def _batched(rows: list[tuple[Any, ...]], size: int) -> Iterable[list[tuple[Any, ...]]]:
+    for i in range(0, len(rows), size):
+        yield rows[i : i + size]
+
+
+def _insert_sql(table: Table, row_count: int) -> str:
+    row_select = "SELECT " + ",".join(_placeholder(table, i) for i in range(len(table.columns)))
+    values_sql = " UNION ALL ".join(row_select for _ in range(row_count))
+    return f"INSERT INTO {_table_name(table)} {values_sql}"
+
+
+def _merge_sql(table: Table, row_count: int) -> str:
+    if not table.primary_key:
+        raise NotesOnError("upsert requires a table primary key")
+    source_select = _source_select_sql(table, row_count)
+    match_sql = " AND ".join(
+        f"target.{_identifier(column)} = source.{_identifier(column)}" for column in table.primary_key
+    )
+    non_key_columns = [column.name for column in table.columns if column.name not in table.primary_key]
+    update_sql = ", ".join(
+        f"target.{_identifier(column)} = source.{_identifier(column)}" for column in non_key_columns
+    )
+    insert_columns = ", ".join(_identifier(column.name) for column in table.columns)
+    insert_values = ", ".join(f"source.{_identifier(column.name)}" for column in table.columns)
+    matched_sql = f"WHEN MATCHED THEN UPDATE SET {update_sql}\n" if update_sql else ""
+    return (
+        f"MERGE INTO {_table_name(table)} AS target\n"
+        f"USING ({source_select}) AS source\n"
+        f"ON {match_sql}\n"
+        f"{matched_sql}"
+        f"WHEN NOT MATCHED THEN INSERT ({insert_columns}) VALUES ({insert_values})"
+    )
+
+
+def _source_select_sql(table: Table, row_count: int) -> str:
+    row_select = "SELECT " + ", ".join(
+        f"{_placeholder(table, i)} AS {_identifier(column.name)}" for i, column in enumerate(table.columns)
+    )
+    return " UNION ALL ".join(row_select for _ in range(row_count))
+
+
+def _placeholder(table: Table, index: int) -> str:
+    if index in table.variant_indexes:
+        return "PARSE_JSON(%s)"
+    return "%s"
+
+
+def _flatten(rows: list[tuple[Any, ...]]) -> tuple[Any, ...]:
+    return tuple(value for row in rows for value in row)
+
+
+def _create_table_sql(table: Table) -> str:
+    return _create_table_statement_sql("CREATE OR REPLACE TABLE", table)
+
+
+def _create_table_if_not_exists_sql(table: Table) -> str:
+    return _create_table_statement_sql("CREATE TABLE IF NOT EXISTS", table)
+
+
+def _create_table_statement_sql(prefix: str, table: Table) -> str:
+    definitions = []
+    for column in table.columns:
+        sql = f"{column.name} {_type_sql(column.kind)}"
+        if not column.nullable:
+            sql += " NOT NULL"
+        definitions.append(sql)
+    if table.primary_key:
+        definitions.append(f"PRIMARY KEY ({', '.join(table.primary_key)})")
+    return f"{prefix} {_table_name(table)} (\n    " + ",\n    ".join(definitions) + "\n)"
+
+
+def _table_name(table: Table) -> str:
+    return f"{AGENTS_SCHEMA}.{_identifier(table.name)}"
+
+
+def _identifier(identifier: str) -> str:
+    if not IDENTIFIER_RE.fullmatch(identifier):
+        raise NotesOnError(f"expected a simple Snowflake identifier: {identifier}")
+    return identifier
+
+
+def _type_sql(kind: str) -> str:
+    if kind == "float":
+        return "FLOAT"
+    if kind == "text":
+        return "TEXT"
+    if kind == "timestamp":
+        return "TIMESTAMP"
+    if kind == "variant":
+        return "VARIANT"
+    if kind == "varchar":
+        return "VARCHAR"
+    raise ValueError(f"unsupported column kind: {kind}")

--- a/examples/providers/notes_on/tests/test_provider.py
+++ b/examples/providers/notes_on/tests/test_provider.py
@@ -1,0 +1,257 @@
+import os
+import tempfile
+import textwrap
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+from agents_schema_notes_on import provider
+from agents_schema_notes_on.cli import main
+from agents_schema_notes_on.provider import NotesOnError
+
+
+class FakeDestination:
+    def __init__(self):
+        self.calls = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return None
+
+    def upsert_rows(self, table, rows):
+        self.calls.append(("upsert", table.name, list(rows)))
+
+    def replace_table(self, table):
+        self.calls.append(("replace", table.name))
+
+    def insert_rows(self, table, rows):
+        self.calls.append(("insert", table.name, list(rows)))
+
+
+class NotesOnProviderTests(unittest.TestCase):
+    def test_load_notes_file_returns_schema_table_and_column_rows(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "notes.yml"
+            path.write_text(
+                textwrap.dedent(
+                    """
+                    schema_notes:
+                      - note_id: sales_schema_time_policy
+                        schema_name: sales
+                        kind: time_policy
+                        tags: [finance, revenue]
+                        content: Use closed_at unless the question asks about pipeline creation.
+                        confidence: 0.95
+                        importance: 0.8
+                    table_notes:
+                      - note_id: zendesk_ticket_grain
+                        table_schema: zendesk
+                        table_name: ticket
+                        kind: grain_warning
+                        content: One row is one current ticket.
+                    column_notes:
+                      - note_id: stripe_invoice_amount_due_cents
+                        table_schema: stripe
+                        table_name: invoice
+                        column_name: amount_due
+                        kind: unit_rule
+                        tags: [stripe, money]
+                        content: Stripe amount columns are stored in cents.
+                    """
+                )
+            )
+
+            schema_rows, table_rows, column_rows = provider.load_notes_file(path)
+
+        self.assertEqual(schema_rows[0][:6], (
+            "sales_schema_time_policy",
+            "sales",
+            "time_policy",
+            ["finance", "revenue"],
+            None,
+            "Use closed_at unless the question asks about pipeline creation.",
+        ))
+        self.assertEqual(table_rows[0][:6], (
+            "zendesk_ticket_grain",
+            None,
+            "zendesk",
+            "ticket",
+            "grain_warning",
+            None,
+        ))
+        self.assertEqual(column_rows[0][:7], (
+            "stripe_invoice_amount_due_cents",
+            None,
+            "stripe",
+            "invoice",
+            "amount_due",
+            "unit_rule",
+            ["stripe", "money"],
+        ))
+
+    def test_load_notes_file_rejects_duplicate_note_ids(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "notes.yml"
+            path.write_text(
+                textwrap.dedent(
+                    """
+                    table_notes:
+                      - note_id: duplicate
+                        table_schema: zendesk
+                        table_name: ticket
+                        kind: grain_warning
+                        content: Table note.
+                    column_notes:
+                      - note_id: duplicate
+                        table_schema: zendesk
+                        table_name: ticket
+                        column_name: status
+                        kind: status_mapping
+                        content: Column note.
+                    """
+                )
+            )
+
+            with self.assertRaisesRegex(NotesOnError, "duplicate note_id: duplicate"):
+                provider.load_notes_file(path)
+
+    def test_load_notes_file_rejects_bad_tags(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "notes.yml"
+            path.write_text(
+                textwrap.dedent(
+                    """
+                    schema_notes:
+                      - note_id: bad_tags
+                        schema_name: sales
+                        kind: time_policy
+                        tags: [finance, 123]
+                        content: Use closed_at.
+                    """
+                )
+            )
+
+            with self.assertRaisesRegex(NotesOnError, "schema_notes\\[0\\]\\.tags must be a list of strings"):
+                provider.load_notes_file(path)
+
+    def test_load_notes_file_rejects_bad_score(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "notes.yml"
+            path.write_text(
+                textwrap.dedent(
+                    """
+                    table_notes:
+                      - note_id: bad_confidence
+                        table_schema: zendesk
+                        table_name: ticket
+                        kind: grain_warning
+                        content: Table note.
+                        confidence: 2.0
+                    """
+                )
+            )
+
+            with self.assertRaisesRegex(NotesOnError, "table_notes\\[0\\]\\.confidence must be between 0 and 1"):
+                provider.load_notes_file(path)
+
+    def test_run_writes_root_and_note_tables(self):
+        dest = FakeDestination()
+
+        with (
+            tempfile.TemporaryDirectory() as tmp,
+            patch("agents_schema_notes_on.provider.SnowflakeDestination.from_env", return_value=dest),
+            redirect_stdout(StringIO()),
+        ):
+            path = Path(tmp) / "notes.yml"
+            path.write_text(
+                textwrap.dedent(
+                    """
+                    column_notes:
+                      - note_id: stripe_invoice_amount_due_cents
+                        table_schema: stripe
+                        table_name: invoice
+                        column_name: amount_due
+                        kind: unit_rule
+                        content: Stripe amount columns are stored in cents.
+                    """
+                )
+            )
+
+            provider.run(path)
+
+        self.assertEqual(dest.calls[0][0], "upsert")
+        self.assertEqual(dest.calls[0][1], "root")
+        self.assertEqual({row[0] for row in dest.calls[0][2]}, {"notes_on"})
+        self.assertIn(
+            (
+                "notes_on",
+                "schemata",
+                "One row per note attached to a warehouse schema. See AGENTS.NOTES_ON_SCHEMATA.",
+            ),
+            dest.calls[0][2],
+        )
+        self.assertEqual([call[0] for call in dest.calls[1:4]], ["replace", "replace", "replace"])
+        self.assertEqual(dest.calls[1][1], "notes_on_schemata")
+        self.assertEqual(dest.calls[4][0], "insert")
+        self.assertEqual(dest.calls[4][1], "notes_on_columns")
+
+    def test_cli_returns_clean_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "notes.yml"
+            path.write_text("column_notes: {}\n")
+
+            with redirect_stderr(StringIO()):
+                status = main(["--notes-file", str(path)])
+
+        self.assertEqual(status, 1)
+
+    def test_variant_values_are_bound_as_json(self):
+        rows = provider._bind_rows(provider.NOTES_ON_COLUMNS, [(
+            "stripe_invoice_amount_due_cents",
+            None,
+            "stripe",
+            "invoice",
+            "amount_due",
+            "unit_rule",
+            ["stripe", "money"],
+            None,
+            "Stripe amount columns are stored in cents.",
+            None,
+            None,
+            0.9,
+            1.0,
+            None,
+            None,
+        )])
+
+        self.assertEqual(rows[0][6], '["stripe", "money"]')
+        self.assertIn("PARSE_JSON(%s)", provider._insert_sql(provider.NOTES_ON_COLUMNS, 1))
+
+    def test_warehouse_credentials_from_env_accepts_yaml(self):
+        with patch.dict(
+            os.environ,
+            {
+                "WAREHOUSE_CREDENTIALS": textwrap.dedent(
+                    """
+                    type: snowflake
+                    account: example
+                    user: service_user
+                    warehouse: transform_wh
+                    database: analytics
+                    password: secret
+                    """
+                )
+            },
+        ):
+            creds = provider.warehouse_credentials_from_env()
+
+        self.assertEqual(creds["type"], "snowflake")
+        self.assertEqual(creds["database"], "analytics")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds `notes_on`, an optional Agents Schema provider under `examples/providers/notes_on` for teams that want a durable note layer on warehouse schemas, tables, and columns. It is useful as-is for agents, catalogs, review workflows, or analytics tooling that need object-scoped notes.

This is not a built-in/core provider and does not require everyone adopting Agents Schema to adopt this note shape. It does not change the core `agents-schema` CLI, core `ROOT_ENTRIES`, reusable workflows, package metadata, or the official `SPEC.md`.

The provider publishes durable object-scoped notes using provider-prefixed tables:

- `AGENTS.NOTES_ON_SCHEMATA`
- `AGENTS.NOTES_ON_TABLES`
- `AGENTS.NOTES_ON_COLUMNS`

It also upserts provider-authored `AGENTS.ROOT` rows at runtime. Those rows are deployment/provider metadata, not new core registry entries.

## Implementation

The package includes:

- a standalone `agents-schema-notes-on` CLI
- YAML source parsing and validation
- Snowflake publishing for the three `NOTES_ON_*` tables
- provider-owned `AGENTS.ROOT` upsert behavior
- sample YAML input
- standalone SQL snippets for tables, root rows, and context aggregations
- unit tests for parsing, validation, SQL binding, credentials, CLI errors, and publish flow

## Positioning

This reframes the old memory idea as an optional provider rather than a core Agents Schema feature. The shape is intentionally narrow: physical schema/table/column notes, no agent memory state, no write-back semantics, no polymorphic anchors, and no requirement that other providers or consumers adopt these opinions.

The useful distinction from database comments is still preserved: multiple authors, provenance, tags, confidence, importance, and history without overwriting a single canonical object comment.

## Context view compatibility

The provider id is `notes_on`, so the table names line up with the context-view naming scheme from #12. Since the source tables are one row per note, any `AGENTS.SCHEMATA`/`TABLES`/`COLUMNS` enrichment should aggregate to object grain before joining. The example uses a `notes_on_notes` VARIANT array rather than concatenated text so note boundaries and provenance are preserved.

## Verification

```text
uv run python -m unittest discover -s tests
Ran 7 tests
OK

PYTHONPATH=examples/providers/notes_on/src uv run python -m unittest discover -s examples/providers/notes_on/tests
Ran 8 tests
OK

uv run python -m compileall -q src examples/providers/notes_on/src
git diff --check
clean
```
