### PR TITLE
add: Warehouse-delivered skills

### DIFF
--- a/.github/actions/agents-schema-dbt/action.yml
+++ b/.github/actions/agents-schema-dbt/action.yml
@@ -59,7 +59,7 @@ runs:
             adapter_args+=(--target "$DBT_TARGET")
           fi
           DBT_ADAPTER_PACKAGE="$(
-            uvx --from "agents-schema==0.0.6" \
+            uvx --from "agents-schema==0.0.7" \
               agents-schema-dbt-adapter-package "${adapter_args[@]}"
           )"
           echo "Using dbt adapter package $DBT_ADAPTER_PACKAGE from DBT_PROFILES_YML"
@@ -112,5 +112,5 @@ runs:
     - name: Run dbt ingestion
       shell: bash
       run: |
-        uvx --from "agents-schema==0.0.6" \
+        uvx --from "agents-schema==0.0.7" \
           agents-schema dbt --project-dir "${{ inputs.dbt-project-dir }}"

--- a/.github/actions/agents-schema-looker/action.yml
+++ b/.github/actions/agents-schema-looker/action.yml
@@ -17,5 +17,5 @@ runs:
     - name: Run Looker ingestion
       shell: bash
       run: |
-        uvx --from "agents-schema==0.0.6" \
+        uvx --from "agents-schema==0.0.7" \
           agents-schema looker --lookml-dir "${{ inputs.lookml-dir }}"

--- a/.github/actions/agents-schema-osi/action.yml
+++ b/.github/actions/agents-schema-osi/action.yml
@@ -17,5 +17,5 @@ runs:
     - name: Run OSI ingestion
       shell: bash
       run: |
-        uvx --from "agents-schema==0.0.6" \
+        uvx --from "agents-schema==0.0.7" \
           agents-schema osi --osi-dir "${{ inputs.osi-dir }}"

--- a/.github/actions/agents-schema-skills/action.yml
+++ b/.github/actions/agents-schema-skills/action.yml
@@ -1,0 +1,27 @@
+name: 'Agents Schema Skills'
+description: >
+  Ingests markdown skills into AGENTS.ROOT and parsed uses into AGENTS.SKILL_USE.
+
+inputs:
+  skills-dir:
+    description: 'Path to a directory containing markdown skill files'
+    required: true
+  provider:
+    description: 'Publisher name to use for AGENTS.ROOT skill rows'
+    required: false
+    default: 'user'
+runs:
+  using: composite
+  steps:
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v5
+      with:
+        python-version: '3.12'
+
+    - name: Run skills ingestion
+      shell: bash
+      run: |
+        uvx --from "agents-schema==0.0.6" \
+          agents-schema skills \
+            --skills-dir "${{ inputs.skills-dir }}" \
+            --provider "${{ inputs.provider }}"

--- a/.github/actions/agents-schema-skills/action.yml
+++ b/.github/actions/agents-schema-skills/action.yml
@@ -21,7 +21,7 @@ runs:
     - name: Run skills ingestion
       shell: bash
       run: |
-        uvx --from "agents-schema==0.0.6" \
+        uvx --from "agents-schema==0.0.7" \
           agents-schema skills \
             --skills-dir "${{ inputs.skills-dir }}" \
             --provider "${{ inputs.provider }}"

--- a/.github/workflows/agents-schema-dbt.yml
+++ b/.github/workflows/agents-schema-dbt.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run dbt ingestion
-        uses: fivetran/agents_schema/.github/actions/agents-schema-dbt@v0.0.6
+        uses: fivetran/agents_schema/.github/actions/agents-schema-dbt@v0.0.7
         with:
           dbt-project-dir: ${{ inputs.dbt-project-dir }}
           dbt-profile-name: ${{ inputs.dbt-profile-name }}

--- a/.github/workflows/agents-schema-looker.yml
+++ b/.github/workflows/agents-schema-looker.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Looker ingestion
-        uses: fivetran/agents_schema/.github/actions/agents-schema-looker@v0.0.6
+        uses: fivetran/agents_schema/.github/actions/agents-schema-looker@v0.0.7
         with:
           lookml-dir: ${{ inputs.lookml-dir }}
         env:

--- a/.github/workflows/agents-schema-osi.yml
+++ b/.github/workflows/agents-schema-osi.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run OSI ingestion
-        uses: fivetran/agents_schema/.github/actions/agents-schema-osi@v0.0.6
+        uses: fivetran/agents_schema/.github/actions/agents-schema-osi@v0.0.7
         with:
           osi-dir: ${{ inputs.osi-dir }}
         env:

--- a/.github/workflows/agents-schema-skills.yml
+++ b/.github/workflows/agents-schema-skills.yml
@@ -1,0 +1,33 @@
+name: Agents Schema Skills
+
+on:
+  workflow_call:
+    inputs:
+      skills-dir:
+        description: 'Path to a directory containing markdown skill files'
+        type: string
+        required: true
+      provider:
+        description: 'Publisher name to use for AGENTS.ROOT skill rows'
+        type: string
+        required: false
+        default: 'user'
+    secrets:
+      WAREHOUSE_CREDENTIALS:
+        required: true
+
+jobs:
+  ingest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Run skills ingestion
+        uses: fivetran/agents_schema/.github/actions/agents-schema-skills@v0.0.6
+        with:
+          skills-dir: ${{ inputs.skills-dir }}
+          provider: ${{ inputs.provider }}
+        env:
+          WAREHOUSE_CREDENTIALS: ${{ secrets.WAREHOUSE_CREDENTIALS }}

--- a/.github/workflows/agents-schema-skills.yml
+++ b/.github/workflows/agents-schema-skills.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run skills ingestion
-        uses: fivetran/agents_schema/.github/actions/agents-schema-skills@v0.0.6
+        uses: fivetran/agents_schema/.github/actions/agents-schema-skills@v0.0.7
         with:
           skills-dir: ${{ inputs.skills-dir }}
           provider: ${{ inputs.provider }}

--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ source-specific workflows.
 2. The workflow checks out your repository and reads source metadata such as
    dbt artifacts, LookML files, or OSI YAML files.
 3. The workflow runs the `agents-schema` CLI at the pinned release tag.
-4. The CLI writes normalized metadata into the warehouse under the `AGENTS`
-   schema.
+4. The CLI writes normalized metadata and warehouse-delivered skills into the
+   warehouse under the `AGENTS` schema.
 5. Agents and downstream tools query `AGENTS` for context close to the data
    itself.
 
@@ -153,9 +153,21 @@ The GitHub Actions call the CLI with explicit source arguments:
 agents-schema dbt --project-dir dbt_project
 agents-schema looker --lookml-dir lookml
 agents-schema osi --osi-dir osi
+agents-schema skills --skills-dir skills
 ```
 
-The CLI reads warehouse credentials from `WAREHOUSE_CREDENTIALS`.
+The CLI reads warehouse credentials from `WAREHOUSE_CREDENTIALS`. Skills default
+to `--provider user`; pass `--provider fivetran` or another reserved provider
+when publishing vendor-delivered skills.
+
+Skills are delivered as `AGENTS.ROOT` rows whose keys start with `skill/`:
+
+```sql
+SELECT provider, key, content
+FROM AGENTS.ROOT
+WHERE key LIKE 'skill/%'
+ORDER BY provider, key;
+```
 
 ### Versioning
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ not guesses. You need a `snow` CLI connection (run `snow connection add` if you 
 ```bash
 curl -fsSL --create-dirs \
   -o ~/.claude/skills/agents-schema-analyst/SKILL.md \
-  https://raw.githubusercontent.com/fivetran/agents_schema/v0.0.6/examples/skills/agents-schema-analyst/SKILL.md
+  https://raw.githubusercontent.com/fivetran/agents_schema/v0.0.7/examples/skills/agents-schema-analyst/SKILL.md
 ```
 
 Then ask: `/agents-schema-analyst "What is our total MRR this month?"`
@@ -96,7 +96,7 @@ Then ask: `/agents-schema-analyst "What is our total MRR this month?"`
 ```bash
 curl -fsSL --create-dirs \
   -o ~/.codex/skills/agents-schema-analyst/SKILL.md \
-  https://raw.githubusercontent.com/fivetran/agents_schema/v0.0.6/examples/skills/agents-schema-analyst/SKILL.md
+  https://raw.githubusercontent.com/fivetran/agents_schema/v0.0.7/examples/skills/agents-schema-analyst/SKILL.md
 ```
 
 Then ask: `$agents-schema-analyst "What is our total MRR this month?"`
@@ -177,11 +177,11 @@ source, examples, README, and spec.
 Pin exact tags in your workflows:
 
 ```yaml
-uses: fivetran/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.6
+uses: fivetran/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.7
 ```
 
 To upgrade, change only the tag in the `uses:` line. The current release tag is
-`v0.0.6`.
+`v0.0.7`.
 
 ### Specification
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -37,7 +37,7 @@ GitHub `release: published` event.
 5. Tag the release:
 
    ```bash
-   git tag v0.0.6
+   git tag v0.0.7
    git push origin main --tags
    ```
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -25,9 +25,9 @@ The implementation writes unquoted identifiers, so Snowflake stores table and co
 
 ## `AGENTS.ROOT`
 
-`AGENTS.ROOT` is the intended provider registry for the Agents Schema. It gives generic consumers one place to discover which providers have published metadata and how to use their tables.
+`AGENTS.ROOT` is the intended provider registry for the Agents Schema. It gives generic consumers one place to discover which providers have published metadata, how to use their tables, and which warehouse-delivered skills are available.
 
-The current dbt, LookML, and OSI ingestion workflows upsert their own provider rows into `AGENTS.ROOT` and write the source-specific tables documented below. Each workflow preserves `ROOT` rows from other providers.
+The current dbt, LookML, OSI, and skills ingestion workflows upsert their own provider rows into `AGENTS.ROOT` and write the source-specific tables documented below. Each workflow preserves `ROOT` rows from other providers.
 
 ```sql
 CREATE TABLE AGENTS.ROOT (
@@ -40,7 +40,7 @@ CREATE TABLE AGENTS.ROOT (
 
 | Column | Description |
 |---|---|
-| `provider` | A short, lowercase identifier for the metadata contributor, such as `dbt`, `lookml`, or `osi`. |
+| `provider` | A short, lowercase identifier for the metadata contributor, such as `dbt`, `lookml`, `osi`, `skills`, `fivetran`, or `user`. |
 | `key` | Provider-defined identifier, unique within the provider. For table documentation, the recommended convention is the unprefixed table name, such as `model` for `AGENTS.DBT_MODEL`. |
 | `content` | Free-form context about the provider, table, convention, skill, or anything else the provider wants discoverable. |
 
@@ -49,6 +49,41 @@ CREATE TABLE AGENTS.ROOT (
 A row in `AGENTS.ROOT` can hold any text a provider wants discoverable from inside the warehouse. The only hard rule is that `(provider, key)` is unique. Beyond that, providers are free to use rows however they like: for an overview, conventions, per-table notes, skills, query recipes, deprecation notices, or anything else worth publishing alongside the data. Markdown is a natural fit because consumers are often LLMs, but the column is plain text and any shape works.
 
 It is strongly recommended that when a row is meant to document a specific contributed table, its key match the unprefixed table name. For example, `(dbt, model)` documents `AGENTS.DBT_MODEL`, and `(lookml, explore)` documents `AGENTS.LOOKML_EXPLORE`. This is not enforced, but following the convention keeps consumers, especially LLM agents, from getting confused about whether a row describes a table or is freeform context.
+
+### Skill rows in `ROOT`
+
+Skills are agent-readable instructions delivered through `AGENTS.ROOT`. A skill row uses the convention:
+
+```
+provider = <publisher>
+key      = skill/<name>
+content  = markdown skill body
+```
+
+The skill body may include YAML frontmatter. The only standard frontmatter field in this version is `uses`, which declares the additive set of schemas and tables the skill may use:
+
+```markdown
+---
+uses:
+  schemas:
+    - QUICKSTART_FINANCE
+  tables:
+    - QUICKSTART_FINANCE.ARR_SNAPSHOT
+---
+
+# Revenue Skill
+
+Use this skill when answering ARR, MRR, recurring revenue, or revenue trend questions.
+```
+
+`uses.schemas` means the skill may use all tables in that schema. `uses.tables` entries must be schema-qualified table names. The lists are additive and do not express exclusions. Consumers can read skills with:
+
+```sql
+SELECT provider, key, content
+FROM AGENTS.ROOT
+WHERE key LIKE 'skill/%'
+ORDER BY provider, key;
+```
 
 ### Example rows
 
@@ -64,7 +99,9 @@ lookml     explore                   One row per LookML explore. See AGENTS.LOOK
 osi        overview                  # OSI\nOpen Semantic Interchange metadata.
 osi        dataset                   One row per OSI dataset. See AGENTS.OSI_DATASET.
 osi        metric                    One row per OSI metric. See AGENTS.OSI_METRIC.
-acme_corp  skills/refund_workflow    # Refund Workflow\nWhen a user asks about refunds...
+skills     overview                  # Skills\nWarehouse-delivered agent skills...
+skills     skill_use                 Optional parsed skill data-use declarations.
+acme_corp  skill/refund_workflow     # Refund Workflow\nWhen a user asks about refunds...
 acme_corp  costs                     # Query Costs\nUse this before running expensive joins.
 ```
 
@@ -79,8 +116,38 @@ The current package delivers one table family per metadata source:
 | dbt | `AGENTS.DBT_MODEL`, `AGENTS.DBT_COLUMN`, `AGENTS.DBT_DEPENDENCY` |
 | LookML | `AGENTS.LOOKML_VIEW`, `AGENTS.LOOKML_DIMENSION`, `AGENTS.LOOKML_MEASURE`, `AGENTS.LOOKML_EXPLORE` |
 | OSI | `AGENTS.OSI_DATASET`, `AGENTS.OSI_FIELD`, `AGENTS.OSI_METRIC`, `AGENTS.OSI_RELATIONSHIP` |
+| Skills | `AGENTS.SKILL_USE` |
 
 Each ingestion replaces its own table family with `CREATE OR REPLACE TABLE` and then inserts the rows parsed from the source metadata.
+
+---
+
+## Source: Skills
+
+The skills ingestion reads markdown files and publishes each file as a skill row in `AGENTS.ROOT`. It also parses compliant `uses` frontmatter into `AGENTS.SKILL_USE` so consumers can quickly find which skills may use a schema or table.
+
+Skill rows are stored in `AGENTS.ROOT` under the publisher passed to the CLI. The skills CLI defaults to `--provider user`. For example, `skills/revenue/arr.md` without an explicit provider is published as `(user, skill/revenue/arr)`, while the same file with `--provider fivetran` is published as `(fivetran, skill/revenue/arr)`.
+
+### `AGENTS.SKILL_USE`
+
+One row per parsed skill use declaration. Missing frontmatter produces no rows. Malformed `uses` frontmatter should not block publication of the skill markdown to `AGENTS.ROOT`, but should be skipped for `AGENTS.SKILL_USE`.
+
+```sql
+CREATE OR REPLACE TABLE AGENTS.SKILL_USE (
+  provider   VARCHAR NOT NULL,
+  skill_key  VARCHAR NOT NULL,
+  use_kind   VARCHAR NOT NULL,
+  object_ref VARCHAR NOT NULL,
+  PRIMARY KEY (provider, skill_key, use_kind, object_ref)
+);
+```
+
+| Column | Description |
+|---|---|
+| `provider` | Publisher used for the corresponding `AGENTS.ROOT` skill row. |
+| `skill_key` | `AGENTS.ROOT.key` value for the skill, such as `skill/revenue/arr`. |
+| `use_kind` | Either `schema` or `table`. |
+| `object_ref` | Schema name for `schema`, or schema-qualified table name for `table`. |
 
 ---
 
@@ -425,9 +492,9 @@ Agents Schema tables can be populated in several ways:
 - **Vendor-run pipelines** that sync provider metadata into the warehouse
 - **CI/CD jobs** that parse source artifacts and load `AGENTS.*` tables after project changes
 - **Scheduled workflows** that periodically refresh metadata from source systems or repositories
-- **Platform engineering jobs** that maintain custom provider tables for internal metadata, skills, query recipes, or operational context
+- **Platform engineering jobs** that maintain user-published provider tables for internal metadata, skills, query recipes, or operational context
 
-This repository currently provides source-specific GitHub reusable workflows for dbt, LookML, and OSI ingestion. Those workflows are one implementation path, not a requirement that all Agents Schema metadata be produced through GitHub Actions.
+This repository currently provides source-specific GitHub reusable workflows for dbt, LookML, OSI, and skills ingestion. Those workflows are one implementation path, not a requirement that all Agents Schema metadata be produced through GitHub Actions.
 
 Each source ingestion owns its table family and may replace those tables on each run. Consumers should treat these tables as generated metadata, not as hand-edited state.
 
@@ -438,13 +505,15 @@ Each source ingestion owns its table family and may replace those tables on each
 
 ### Provider Names
 
-The current source provider names are:
+The following provider names are reserved:
 
-| Provider | Tables |
+| Provider | Purpose |
 |---|---|
-| `dbt` | `AGENTS.DBT_*` |
-| `lookml` | `AGENTS.LOOKML_*` |
-| `osi` | `AGENTS.OSI_*` |
+| `dbt` | dbt metadata in `AGENTS.DBT_*` |
+| `lookml` | LookML metadata in `AGENTS.LOOKML_*` |
+| `osi` | OSI metadata in `AGENTS.OSI_*` |
+| `skills` | Skills extension metadata in `AGENTS.SKILL_USE` |
+| `user` | User-published skills, metadata, query recipes, or operational context |
 
 ---
 
@@ -452,7 +521,8 @@ The current source provider names are:
 
 | Table | Source | Purpose |
 |---|---|---|
-| `AGENTS.ROOT` | core | Provider registry upserted by dbt, LookML, and OSI workflows |
+| `AGENTS.ROOT` | core | Provider registry and skill delivery surface upserted by source workflows |
+| `AGENTS.SKILL_USE` | skills | Parsed skill schema and table use declarations |
 | `AGENTS.DBT_MODEL` | dbt | dbt models with schema, materialization, documentation, path, and tags |
 | `AGENTS.DBT_COLUMN` | dbt | Documented dbt model columns |
 | `AGENTS.DBT_DEPENDENCY` | dbt | Direct dbt dependency edges |

--- a/dbt-setup.md
+++ b/dbt-setup.md
@@ -47,7 +47,7 @@ on:
 
 jobs:
   agents-schema-dbt:
-    uses: fivetran/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.6
+    uses: fivetran/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.7
     with:
       dbt-project-dir: dbt_project
     secrets: inherit

--- a/examples/skills/agents-schema-analyst/SKILL.md
+++ b/examples/skills/agents-schema-analyst/SKILL.md
@@ -36,7 +36,7 @@ hard-coding them.
    ```sql
    SELECT provider, key, content FROM AGENTS.ROOT ORDER BY provider, key;
    ```
-   This lists the providers that published metadata (`osi`, `lookml`, `dbt`, or custom) plus
+   This lists the providers that published metadata (`osi`, `lookml`, `dbt`, or user-published) plus
    their overview/guidance rows. Only query tables for providers that actually appear here.
 
 2. **Find the metric.** Search the semantic definition tables for keywords from the question

--- a/examples/warehouse-skills/revenue.md
+++ b/examples/warehouse-skills/revenue.md
@@ -1,0 +1,13 @@
+---
+uses:
+  schemas:
+    - QUICKSTART_FINANCE
+  tables:
+    - QUICKSTART_FINANCE.ARR_SNAPSHOT
+---
+
+# Revenue Skill
+
+Use this skill when answering ARR, MRR, recurring revenue, or revenue trend questions.
+
+Resolve the relevant metric definition from warehouse metadata before querying the physical table. Use the tables and schemas declared in the frontmatter as the allowed starting surface for this skill.

--- a/examples/workflows/dbt-looker-osi.yml
+++ b/examples/workflows/dbt-looker-osi.yml
@@ -7,19 +7,19 @@ on:
 
 jobs:
   agents-schema-dbt:
-    uses: fivetran/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.6
+    uses: fivetran/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.7
     with:
       dbt-project-dir: dbt_project
     secrets: inherit
 
   agents-schema-looker:
-    uses: fivetran/agents_schema/.github/workflows/agents-schema-looker.yml@v0.0.6
+    uses: fivetran/agents_schema/.github/workflows/agents-schema-looker.yml@v0.0.7
     with:
       lookml-dir: lookml
     secrets: inherit
 
   agents-schema-osi:
-    uses: fivetran/agents_schema/.github/workflows/agents-schema-osi.yml@v0.0.6
+    uses: fivetran/agents_schema/.github/workflows/agents-schema-osi.yml@v0.0.7
     with:
       osi-dir: osi
     secrets: inherit

--- a/examples/workflows/dbt-looker.yml
+++ b/examples/workflows/dbt-looker.yml
@@ -7,13 +7,13 @@ on:
 
 jobs:
   agents-schema-dbt:
-    uses: fivetran/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.6
+    uses: fivetran/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.7
     with:
       dbt-project-dir: dbt_project
     secrets: inherit
 
   agents-schema-looker:
-    uses: fivetran/agents_schema/.github/workflows/agents-schema-looker.yml@v0.0.6
+    uses: fivetran/agents_schema/.github/workflows/agents-schema-looker.yml@v0.0.7
     with:
       lookml-dir: lookml
     secrets: inherit

--- a/examples/workflows/dbt-with-parse.yml
+++ b/examples/workflows/dbt-with-parse.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   agents-schema-dbt:
-    uses: fivetran/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.6
+    uses: fivetran/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.7
     with:
       dbt-project-dir: dbt_project
       dbt-profile-name: analytics

--- a/examples/workflows/dbt.yml
+++ b/examples/workflows/dbt.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   agents-schema-dbt:
-    uses: fivetran/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.6
+    uses: fivetran/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.7
     with:
       dbt-project-dir: dbt_project
     secrets: inherit

--- a/examples/workflows/osi.yml
+++ b/examples/workflows/osi.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   agents-schema-osi:
-    uses: fivetran/agents_schema/.github/workflows/agents-schema-osi.yml@v0.0.6
+    uses: fivetran/agents_schema/.github/workflows/agents-schema-osi.yml@v0.0.7
     with:
       osi-dir: osi
     secrets: inherit

--- a/examples/workflows/skills.yml
+++ b/examples/workflows/skills.yml
@@ -1,0 +1,14 @@
+name: Agents Schema Skills
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+jobs:
+  agents-schema-skills:
+    uses: fivetran/agents_schema/.github/workflows/agents-schema-skills.yml@v0.0.6
+    with:
+      skills-dir: skills
+      provider: fivetran
+    secrets: inherit

--- a/examples/workflows/skills.yml
+++ b/examples/workflows/skills.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   agents-schema-skills:
-    uses: fivetran/agents_schema/.github/workflows/agents-schema-skills.yml@v0.0.6
+    uses: fivetran/agents_schema/.github/workflows/agents-schema-skills.yml@v0.0.7
     with:
       skills-dir: skills
       provider: fivetran

--- a/looker-setup.md
+++ b/looker-setup.md
@@ -45,7 +45,7 @@ on:
 
 jobs:
   agents-schema-looker:
-    uses: fivetran/agents_schema/.github/workflows/agents-schema-looker.yml@v0.0.6
+    uses: fivetran/agents_schema/.github/workflows/agents-schema-looker.yml@v0.0.7
     with:
       lookml-dir: lookml
     secrets: inherit

--- a/osi-setup.md
+++ b/osi-setup.md
@@ -46,7 +46,7 @@ on:
 
 jobs:
   agents-schema-osi:
-    uses: fivetran/agents_schema/.github/workflows/agents-schema-osi.yml@v0.0.6
+    uses: fivetran/agents_schema/.github/workflows/agents-schema-osi.yml@v0.0.7
     with:
       osi-dir: osi
     secrets: inherit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agents-schema"
-version = "0.0.6"
+version = "0.0.7"
 description = "Populate an in-warehouse agents.* schema from dbt manifests, OSI YAML, LookML, and markdown skills."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "agents-schema"
 version = "0.0.6"
-description = "Populate an in-warehouse agents.* schema from dbt manifests, OSI YAML, and LookML."
+description = "Populate an in-warehouse agents.* schema from dbt manifests, OSI YAML, LookML, and markdown skills."
 readme = "README.md"
 requires-python = ">=3.11"
 license = "MIT"

--- a/src/agents_schema/cli.py
+++ b/src/agents_schema/cli.py
@@ -6,7 +6,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from . import __version__, dbt, lookml, osi
+from . import __version__, dbt, lookml, osi, skills
 from .config import ConfigError
 from .dbt_profiles import dbt_adapter_package_from_profiles_file
 from .destinations import warehouse_type_from_env
@@ -64,6 +64,22 @@ def _build_parser() -> argparse.ArgumentParser:
         help="path to a directory containing *.osi.yaml files",
     )
 
+    skills_parser = sub.add_parser(
+        "skills",
+        help="ingest markdown skills into AGENTS.ROOT",
+    )
+    skills_parser.add_argument(
+        "--skills-dir",
+        required=True,
+        type=Path,
+        help="path to a directory containing markdown skill files",
+    )
+    skills_parser.add_argument(
+        "--provider",
+        default="user",
+        help="publisher name to use for AGENTS.ROOT skill rows",
+    )
+
     return parser
 
 
@@ -76,6 +92,10 @@ def main(argv: list[str] | None = None) -> int:
             lookml.run(_config("looker", args.lookml_dir))
         elif args.source_type == "osi":
             osi.run(_config("osi", args.osi_dir))
+        elif args.source_type == "skills":
+            cfg = _config("skills", args.skills_dir)
+            cfg["metadata_connection"]["provider"] = args.provider
+            skills.run(cfg)
         else:
             raise ConfigError(f"unsupported source type: {args.source_type}")
     except (ConfigError, FileNotFoundError) as e:

--- a/src/agents_schema/destinations.py
+++ b/src/agents_schema/destinations.py
@@ -39,17 +39,27 @@ class Destination(Protocol):
     def replace_table(self, table: TableSchema) -> None: ...
     def upsert_rows(self, table: TableSchema, rows: Iterable[tuple[Any, ...]]) -> None: ...
     def insert_rows(self, table: TableSchema, rows: Iterable[tuple[Any, ...]]) -> None: ...
+    def delete_rows(self, table: TableSchema, key_columns: tuple[str, ...], rows: Iterable[tuple[Any, ...]]) -> None: ...
     def close(self) -> None: ...
     def __enter__(self) -> "Destination": ...
     def __exit__(self, exc_type: object, exc: object, tb: object) -> None: ...
 
 
 class SnowflakeDestination:
-    def __init__(self, config: dict[str, Any]) -> None:
+    def __init__(
+        self,
+        config: dict[str, Any] | None = None,
+        *,
+        connect_kwargs: dict[str, Any] | None = None,
+    ) -> None:
         import snowflake.connector
 
         self._agents_schema = AGENTS_SCHEMA
-        self._con = snowflake.connector.connect(**_snowflake_connect_kwargs(config))
+        if connect_kwargs is None:
+            if config is None:
+                raise ConfigError("SnowflakeDestination requires config or connect_kwargs")
+            connect_kwargs = _snowflake_connect_kwargs(config)
+        self._con = snowflake.connector.connect(**connect_kwargs)
 
     def __enter__(self) -> "SnowflakeDestination":
         return self
@@ -83,6 +93,19 @@ class SnowflakeDestination:
             for batch in _batched(bind_rows, INSERT_BATCH_SIZE):
                 cur.execute(_insert_sql(table, self._agents_schema, len(batch)), _flatten(batch))
 
+    def delete_rows(self, table: TableSchema, key_columns: tuple[str, ...], rows: Iterable[tuple[Any, ...]]) -> None:
+        bind_rows = list(rows)
+        if not bind_rows:
+            return
+        with self._con.cursor() as cur:
+            cur.execute(f"CREATE SCHEMA IF NOT EXISTS {self._agents_schema}")
+            cur.execute(_create_table_if_not_exists_sql(table, self._agents_schema))
+            for batch in _batched(bind_rows, INSERT_BATCH_SIZE):
+                cur.execute(
+                    _delete_sql(table, self._agents_schema, key_columns, len(batch)),
+                    _flatten(batch),
+                )
+
 
 def _bind_rows(table: TableSchema, rows: Iterable[tuple[Any, ...]]) -> list[tuple[Any, ...]]:
     bind_rows = []
@@ -106,6 +129,22 @@ def _insert_sql(table: TableSchema, schema: str, row_count: int) -> str:
     row_select = "SELECT " + ",".join(_placeholder(table, i) for i in range(len(table.columns)))
     values_sql = " UNION ALL ".join(row_select for _ in range(row_count))
     return f"INSERT INTO {_table_name(table, schema)} {values_sql}"
+
+
+def _delete_sql(table: TableSchema, schema: str, key_columns: tuple[str, ...], row_count: int) -> str:
+    if not key_columns:
+        raise ConfigError("delete requires at least one key column")
+    source_columns = tuple(Column(name, "varchar", nullable=False) for name in key_columns)
+    source_table = TableSchema(table.name, source_columns)
+    source_select = _source_select_sql(source_table, row_count)
+    match_sql = " AND ".join(
+        f"target.{_identifier(column)} = source.{_identifier(column)}" for column in key_columns
+    )
+    return (
+        f"DELETE FROM {_table_name(table, schema)} AS target\n"
+        f"USING ({source_select}) AS source\n"
+        f"WHERE {match_sql}"
+    )
 
 
 def _merge_sql(table: TableSchema, schema: str, row_count: int) -> str:

--- a/src/agents_schema/root.py
+++ b/src/agents_schema/root.py
@@ -36,6 +36,11 @@ ROOT_ENTRIES = {
         ("metric", "One row per OSI metric. See AGENTS.OSI_METRIC."),
         ("relationship", "One row per OSI relationship. See AGENTS.OSI_RELATIONSHIP."),
     ),
+    "skills": (
+        ("overview", "# Skills\nWarehouse-delivered agent skills published as AGENTS.ROOT rows."),
+        ("root-convention", "Skills are rows in AGENTS.ROOT where key starts with skill/."),
+        ("skill_use", "Optional parsed skill data-use declarations. See AGENTS.SKILL_USE."),
+    ),
 }
 
 

--- a/src/agents_schema/skills.py
+++ b/src/agents_schema/skills.py
@@ -1,0 +1,128 @@
+"""Skills connector: writes markdown skills into AGENTS.ROOT."""
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from .destinations import Column, Destination, TableSchema, open_destination
+from .root import ROOT, upsert_provider_root
+
+__all__ = ["SKILL_USE", "run"]
+
+SKILL_USE = TableSchema(
+    "agents.skill_use",
+    (
+        Column("provider", "varchar", nullable=False),
+        Column("skill_key", "varchar", nullable=False),
+        Column("use_kind", "varchar", nullable=False),
+        Column("object_ref", "varchar", nullable=False),
+    ),
+    primary_key=("provider", "skill_key", "use_kind", "object_ref"),
+)
+
+
+@dataclass(frozen=True)
+class SkillFile:
+    key: str
+    content: str
+    uses: tuple[tuple[str, str], ...]
+    warnings: tuple[str, ...] = ()
+
+
+def run(cfg: dict) -> None:
+    metadata = cfg["metadata_connection"]
+    skills_dir = Path(metadata["path"])
+    provider = metadata["provider"]
+    skills = _load_skill_files(skills_dir)
+    root_rows = [(provider, skill.key, skill.content) for skill in skills]
+    use_rows = [
+        (provider, skill.key, use_kind, object_ref)
+        for skill in skills
+        for use_kind, object_ref in skill.uses
+    ]
+
+    for skill in skills:
+        for warning in skill.warnings:
+            print(f"  skills: warning: {skill.key}: {warning}", file=sys.stderr)
+
+    with open_destination(cfg) as dest:
+        upsert_provider_root(dest, "skills")
+        dest.upsert_rows(ROOT, root_rows)
+        dest.replace_table(SKILL_USE)
+        if use_rows:
+            dest.insert_rows(SKILL_USE, use_rows)
+
+    print(f"  skills:   {len(root_rows)} skills, {len(use_rows)} uses")
+
+
+def _load_skill_files(skills_dir: Path) -> list[SkillFile]:
+    files = sorted(path for path in skills_dir.rglob("*.md") if path.is_file())
+    if not files:
+        raise FileNotFoundError(f"no *.md skill files found in {skills_dir}")
+    return [_load_skill_file(skills_dir, path) for path in files]
+
+
+def _load_skill_file(skills_dir: Path, path: Path) -> SkillFile:
+    rel = path.relative_to(skills_dir)
+    key = "skill/" + rel.with_suffix("").as_posix()
+    content = path.read_text()
+    uses, warnings = _parse_uses_frontmatter(content)
+    return SkillFile(key=key, content=content, uses=uses, warnings=warnings)
+
+
+def _parse_uses_frontmatter(content: str) -> tuple[tuple[tuple[str, str], ...], tuple[str, ...]]:
+    frontmatter, warning = _frontmatter(content)
+    if warning:
+        return (), (warning,)
+    if frontmatter is None:
+        return (), ()
+
+    try:
+        parsed = yaml.safe_load(frontmatter)
+    except yaml.YAMLError as e:
+        return (), (f"invalid YAML frontmatter: {e}",)
+
+    if parsed is None:
+        return (), ()
+    if not isinstance(parsed, dict):
+        return (), ("frontmatter must be a mapping",)
+
+    uses = parsed.get("uses")
+    if uses is None:
+        return (), ()
+    if not isinstance(uses, dict):
+        return (), ("uses must be a mapping",)
+
+    rows: list[tuple[str, str]] = []
+    for field, use_kind in (("schemas", "schema"), ("tables", "table")):
+        values = uses.get(field, [])
+        if values is None:
+            continue
+        if not _is_string_list(values):
+            return (), (f"uses.{field} must be a list of strings",)
+        if field == "tables" and any("." not in value for value in values):
+            return (), ("uses.tables entries must be schema-qualified",)
+        rows.extend((use_kind, value) for value in values)
+
+    extra = sorted(set(uses) - {"schemas", "tables"})
+    if extra:
+        return (), ("uses only supports schemas and tables",)
+    return tuple(rows), ()
+
+
+def _frontmatter(content: str) -> tuple[str | None, str | None]:
+    lines = content.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return None, None
+    for index, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            return "\n".join(lines[1:index]), None
+    return None, "frontmatter opening marker has no closing marker"
+
+
+def _is_string_list(value: Any) -> bool:
+    return isinstance(value, list) and all(isinstance(item, str) and item for item in value)

--- a/src/agents_schema/skills.py
+++ b/src/agents_schema/skills.py
@@ -11,7 +11,7 @@ import yaml
 from .destinations import Column, Destination, TableSchema, open_destination
 from .root import ROOT, upsert_provider_root
 
-__all__ = ["SKILL_USE", "run"]
+__all__ = ["SKILL_USE", "publish_skill", "run"]
 
 SKILL_USE = TableSchema(
     "agents.skill_use",
@@ -57,6 +57,23 @@ def run(cfg: dict) -> None:
             dest.insert_rows(SKILL_USE, use_rows)
 
     print(f"  skills:   {len(root_rows)} skills, {len(use_rows)} uses")
+
+
+def publish_skill(dest: Destination, provider: str, skill_key: str, content: str) -> SkillFile:
+    uses, warnings = _parse_uses_frontmatter(content)
+    skill = SkillFile(key=skill_key, content=content, uses=uses, warnings=warnings)
+    root_rows = [(provider, skill.key, skill.content)]
+    use_rows = [
+        (provider, skill.key, use_kind, object_ref)
+        for use_kind, object_ref in skill.uses
+    ]
+
+    upsert_provider_root(dest, "skills")
+    dest.upsert_rows(ROOT, root_rows)
+    dest.delete_rows(SKILL_USE, ("provider", "skill_key"), [(provider, skill.key)])
+    if use_rows:
+        dest.upsert_rows(SKILL_USE, use_rows)
+    return skill
 
 
 def _load_skill_files(skills_dir: Path) -> list[SkillFile]:

--- a/tests/test_connector_root.py
+++ b/tests/test_connector_root.py
@@ -1,7 +1,8 @@
 import unittest
 from unittest.mock import patch
 
-from agents_schema import dbt, lookml, osi
+from agents_schema import dbt, lookml, osi, skills
+from agents_schema.skills import SkillFile
 
 
 class FakeDestination:
@@ -74,6 +75,31 @@ class ConnectorRootTests(unittest.TestCase):
         self.assertEqual(dest.calls[0][0], "upsert")
         self.assertEqual({row[0] for row in dest.calls[0][2]}, {"osi"})
         self.assertEqual([call[0] for call in dest.calls[1:5]], ["replace", "replace", "replace", "replace"])
+
+    def test_skills_run_upserts_root_before_source_tables(self):
+        dest = FakeDestination()
+        cfg = {"metadata_connection": {"path": ".", "provider": "fivetran"}}
+        skill = SkillFile(
+            key="skill/revenue",
+            content="# Revenue\n",
+            uses=(("schema", "QUICKSTART_FINANCE"), ("table", "QUICKSTART_FINANCE.ARR_SNAPSHOT")),
+        )
+
+        with (
+            patch("agents_schema.skills.open_destination", return_value=DestinationContext(dest)),
+            patch("agents_schema.skills._load_skill_files", return_value=[skill]),
+            patch("builtins.print"),
+        ):
+            skills.run(cfg)
+
+        self.assertEqual(dest.calls[0][0], "upsert")
+        self.assertEqual({row[0] for row in dest.calls[0][2]}, {"skills"})
+        self.assertEqual(dest.calls[1][0], "upsert")
+        self.assertEqual(dest.calls[1][1], "agents.root")
+        self.assertEqual(dest.calls[1][2], [("fivetran", "skill/revenue", "# Revenue\n")])
+        self.assertEqual(dest.calls[2], ("replace", "agents.skill_use"))
+        self.assertEqual(dest.calls[3][0], "insert")
+        self.assertEqual(dest.calls[3][1], "agents.skill_use")
 
 
 if __name__ == "__main__":

--- a/tests/test_connector_root.py
+++ b/tests/test_connector_root.py
@@ -18,6 +18,9 @@ class FakeDestination:
     def insert_rows(self, table, rows):
         self.calls.append(("insert", table.name, list(rows)))
 
+    def delete_rows(self, table, key_columns, rows):
+        self.calls.append(("delete", table.name, key_columns, list(rows)))
+
 
 class DestinationContext:
     def __init__(self, dest):
@@ -100,6 +103,46 @@ class ConnectorRootTests(unittest.TestCase):
         self.assertEqual(dest.calls[2], ("replace", "agents.skill_use"))
         self.assertEqual(dest.calls[3][0], "insert")
         self.assertEqual(dest.calls[3][1], "agents.skill_use")
+
+    def test_publish_skill_upserts_one_root_row_and_refreshes_its_uses(self):
+        dest = FakeDestination()
+        content = (
+            "---\n"
+            "uses:\n"
+            "  schemas:\n"
+            "    - ZENDESK\n"
+            "  tables:\n"
+            "    - ZENDESK.TICKET\n"
+            "---\n"
+            "# Zendesk\n"
+        )
+
+        skill = skills.publish_skill(dest, "fivetran", "skill/zendesk", content)
+
+        self.assertEqual(skill.uses, (("schema", "ZENDESK"), ("table", "ZENDESK.TICKET")))
+        self.assertEqual(dest.calls[0][0], "upsert")
+        self.assertEqual({row[0] for row in dest.calls[0][2]}, {"skills"})
+        self.assertEqual(dest.calls[1], ("upsert", "agents.root", [("fivetran", "skill/zendesk", content)]))
+        self.assertEqual(dest.calls[2], ("delete", "agents.skill_use", ("provider", "skill_key"), [("fivetran", "skill/zendesk")]))
+        self.assertEqual(
+            dest.calls[3],
+            (
+                "upsert",
+                "agents.skill_use",
+                [
+                    ("fivetran", "skill/zendesk", "schema", "ZENDESK"),
+                    ("fivetran", "skill/zendesk", "table", "ZENDESK.TICKET"),
+                ],
+            ),
+        )
+
+    def test_publish_skill_without_uses_only_deletes_stale_use_rows(self):
+        dest = FakeDestination()
+
+        skill = skills.publish_skill(dest, "fivetran", "skill/zendesk", "# Zendesk\n")
+
+        self.assertEqual(skill.uses, ())
+        self.assertEqual(dest.calls[-1], ("delete", "agents.skill_use", ("provider", "skill_key"), [("fivetran", "skill/zendesk")]))
 
 
 if __name__ == "__main__":

--- a/tests/test_destinations.py
+++ b/tests/test_destinations.py
@@ -1,10 +1,18 @@
 import unittest
+from unittest.mock import patch
 
-from agents_schema.destinations import _create_table_if_not_exists_sql, _merge_sql
+from agents_schema.destinations import SnowflakeDestination, _create_table_if_not_exists_sql, _merge_sql
 from agents_schema.root import ROOT
 
 
 class DestinationSqlTests(unittest.TestCase):
+    def test_snowflake_destination_accepts_explicit_connection_kwargs(self):
+        with patch("snowflake.connector.connect") as connect:
+            dest = SnowflakeDestination(connect_kwargs={"account": "acct", "user": "user"})
+
+        connect.assert_called_once_with(account="acct", user="user")
+        dest.close()
+
     def test_root_create_table_uses_if_not_exists(self):
         sql = _create_table_if_not_exists_sql(ROOT, "agents")
 

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -32,6 +32,14 @@ class RootTests(unittest.TestCase):
         _, rows = dest.upserts[0]
         self.assertEqual({row[1] for row in rows}, {"overview", "dataset", "field", "metric", "relationship"})
 
+    def test_upsert_provider_root_has_skills_entries(self):
+        dest = FakeDestination()
+
+        upsert_provider_root(dest, "skills")
+
+        _, rows = dest.upserts[0]
+        self.assertEqual({row[1] for row in rows}, {"overview", "root-convention", "skill_use"})
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1,0 +1,106 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from agents_schema import cli
+from agents_schema.skills import _load_skill_files, _parse_uses_frontmatter
+
+
+class SkillsTests(unittest.TestCase):
+    def test_load_skill_files_discovers_markdown_recursively_and_preserves_content(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            skill_path = root / "revenue" / "arr.md"
+            skill_path.parent.mkdir()
+            content = (
+                "---\n"
+                "uses:\n"
+                "  schemas:\n"
+                "    - QUICKSTART_FINANCE\n"
+                "  tables:\n"
+                "    - QUICKSTART_FINANCE.ARR_SNAPSHOT\n"
+                "---\n"
+                "# ARR\n"
+            )
+            skill_path.write_text(content)
+
+            skills = _load_skill_files(root)
+
+        self.assertEqual(len(skills), 1)
+        self.assertEqual(skills[0].key, "skill/revenue/arr")
+        self.assertEqual(skills[0].content, content)
+        self.assertEqual(
+            skills[0].uses,
+            (("schema", "QUICKSTART_FINANCE"), ("table", "QUICKSTART_FINANCE.ARR_SNAPSHOT")),
+        )
+        self.assertEqual(skills[0].warnings, ())
+
+    def test_load_skill_files_rejects_empty_directory(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaisesRegex(FileNotFoundError, "no \\*.md skill files"):
+                _load_skill_files(Path(tmp))
+
+    def test_parse_uses_frontmatter_accepts_missing_frontmatter(self):
+        uses, warnings = _parse_uses_frontmatter("# Revenue\n")
+
+        self.assertEqual(uses, ())
+        self.assertEqual(warnings, ())
+
+    def test_parse_uses_frontmatter_warns_for_malformed_uses(self):
+        content = "---\nuses:\n  tables: FINANCE.ARR_SNAPSHOT\n---\n# Revenue\n"
+
+        uses, warnings = _parse_uses_frontmatter(content)
+
+        self.assertEqual(uses, ())
+        self.assertEqual(warnings, ("uses.tables must be a list of strings",))
+
+    def test_parse_uses_frontmatter_warns_for_unqualified_tables(self):
+        content = "---\nuses:\n  tables:\n    - ARR_SNAPSHOT\n---\n# Revenue\n"
+
+        uses, warnings = _parse_uses_frontmatter(content)
+
+        self.assertEqual(uses, ())
+        self.assertEqual(warnings, ("uses.tables entries must be schema-qualified",))
+
+    def test_cli_dispatches_skills_with_provider(self):
+        with (
+            patch("agents_schema.cli.warehouse_type_from_env", return_value="snowflake"),
+            patch("agents_schema.cli.skills.run") as run,
+        ):
+            result = cli.main(["skills", "--skills-dir", "skills", "--provider", "fivetran"])
+
+        self.assertEqual(result, 0)
+        run.assert_called_once_with(
+            {
+                "warehouse": {"type": "snowflake"},
+                "metadata_connection": {
+                    "type": "skills",
+                    "path": "skills",
+                    "provider": "fivetran",
+                },
+            }
+        )
+
+    def test_cli_defaults_skills_provider_to_user(self):
+        with (
+            patch("agents_schema.cli.warehouse_type_from_env", return_value="snowflake"),
+            patch("agents_schema.cli.skills.run") as run,
+        ):
+            result = cli.main(["skills", "--skills-dir", "skills"])
+
+        self.assertEqual(result, 0)
+        run.assert_called_once_with(
+            {
+                "warehouse": {"type": "snowflake"},
+                "metadata_connection": {
+                    "type": "skills",
+                    "path": "skills",
+                    "provider": "user",
+                },
+            }
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "agents-schema"
-version = "0.0.6"
+version = "0.0.7"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary

Adds a warehouse-delivered skills path for Agents Schema:

- defines AGENTS.ROOT skill rows with the skill/<name> key convention
- adds agents-schema skills --skills-dir ... --provider ...
- syncs markdown skill files into AGENTS.ROOT
- parses compliant uses.schemas and uses.tables frontmatter into AGENTS.SKILL_USE
- adds a focused publish_skill library API for publishing one skill without replacing all SKILL_USE rows
- lets SnowflakeDestination accept explicit connection kwargs for library callers that already own credential loading
- adds GitHub Action/workflow support and examples
- bumps the package and workflow/action pins to 0.0.7
- documents metadata bootstrap strategies and the new skills contract

## Impact

SQL-capable agents can discover vendor or custom skills directly from the warehouse without a native skill installation mechanism. AGENTS.ROOT remains the portable delivery surface, while AGENTS.SKILL_USE provides an optional structured index for schema/table usage.

The publish_skill API gives service code, such as Fivetran AI connector indexing, a narrow boundary for publishing a single source skill without invoking the CLI or wiping unrelated skill-use rows.

## Validation

- uv run python -m unittest discover -s tests
- uv build --out-dir /private/tmp/agents_schema_dist_007
- uvx twine check /private/tmp/agents_schema_dist_007/agents_schema-0.0.7.tar.gz /private/tmp/agents_schema_dist_007/agents_schema-0.0.7-py3-none-any.whl