### PR TITLE
Add Databricks as a supported write destination

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -4,7 +4,7 @@
 
 Agents Schema gives agents a predictable place to find context about warehouse data: what models exist, what fields mean, how semantic-layer objects are defined, and how those objects relate to each other. See [README.md](./README.md) for motivation, positioning, and GitHub workflow usage.
 
-This document describes the warehouse tables produced by this repository's current ingestion workflows. The SQL below is written in Snowflake form because Snowflake is the currently supported destination.
+This document describes the warehouse tables produced by this repository's current ingestion workflows. Snowflake and Databricks are supported destinations. The SQL below is written in Snowflake form; see [Supported Types](#supported-types) for the Databricks equivalents.
 
 ## Core: The `AGENTS` Schema
 
@@ -14,12 +14,12 @@ The implementation writes unquoted identifiers, so Snowflake stores table and co
 
 ### Supported Types
 
-| Internal kind | Snowflake type | Notes |
-|---|---|---|
-| `varchar` | `VARCHAR` | String values. |
-| `text` | `TEXT` | Longer free-form text. |
-| `boolean` | `BOOLEAN` | Boolean values. |
-| `array` | `VARIANT` | Inserted as JSON via `PARSE_JSON`. |
+| Internal kind | Snowflake type | Databricks type | Notes |
+|---|---|---|---|
+| `varchar` | `VARCHAR` | `STRING` | String values. |
+| `text` | `TEXT` | `STRING` | Longer free-form text. |
+| `boolean` | `BOOLEAN` | `BOOLEAN` | Boolean values. |
+| `array` | `VARIANT` | `STRING` | JSON; Snowflake parses it via `PARSE_JSON`. |
 
 ---
 

--- a/dbt-setup.md
+++ b/dbt-setup.md
@@ -8,8 +8,12 @@ replace tables in the `AGENTS` schema.
 Create one required GitHub Actions secret in the repository that calls these
 workflows: `WAREHOUSE_CREDENTIALS`.
 
-Snowflake is the only supported destination today, with more destination
-support coming soon. We recommend key-pair authentication:
+Snowflake and Databricks are supported destinations. The `type` field in the
+secret selects the destination.
+
+### Snowflake
+
+We recommend key-pair authentication:
 
 **Example key-pair auth secret:**
 
@@ -30,6 +34,22 @@ private_key_passphrase: your-passphrase   # only if the key is encrypted
 **Note:**
 - `role` is optional.
 - An unencrypted key uses `-----BEGIN PRIVATE KEY-----` / `-----END PRIVATE KEY-----` markers and omits `private_key_passphrase`.
+
+### Databricks
+
+Authenticate with a personal access token against a SQL warehouse or cluster.
+
+**Example Databricks secret:**
+
+```yaml
+type: databricks
+server_hostname: dbc-12345678-90ab.cloud.databricks.com
+http_path: /sql/1.0/warehouses/abc123def456
+access_token: <your-databricks-personal-access-token>
+catalog: analytics   # optional; sets the Unity Catalog catalog for the AGENTS schema
+```
+
+**Note:** `catalog` is optional; when omitted, the connection's default catalog is used.
 
 ## Run the dbt Sync Workflow
 

--- a/looker-setup.md
+++ b/looker-setup.md
@@ -8,8 +8,12 @@ replace tables in the `AGENTS` schema.
 Create one required GitHub Actions secret in the repository that calls these
 workflows: `WAREHOUSE_CREDENTIALS`.
 
-Snowflake is the only supported destination today, with more destination
-support coming soon. We recommend key-pair authentication:
+Snowflake and Databricks are supported destinations. The `type` field in the
+secret selects the destination.
+
+### Snowflake
+
+We recommend key-pair authentication:
 
 **Example key-pair auth secret:**
 
@@ -30,6 +34,22 @@ private_key_passphrase: your-passphrase   # only if the key is encrypted
 **Note:**
 - `role` is optional.
 - An unencrypted key uses `-----BEGIN PRIVATE KEY-----` / `-----END PRIVATE KEY-----` markers and omits `private_key_passphrase`.
+
+### Databricks
+
+Authenticate with a personal access token against a SQL warehouse or cluster.
+
+**Example Databricks secret:**
+
+```yaml
+type: databricks
+server_hostname: dbc-12345678-90ab.cloud.databricks.com
+http_path: /sql/1.0/warehouses/abc123def456
+access_token: <your-databricks-personal-access-token>
+catalog: analytics   # optional; sets the Unity Catalog catalog for the AGENTS schema
+```
+
+**Note:** `catalog` is optional; when omitted, the connection's default catalog is used.
 
 ## Run the Looker Sync Workflow
 

--- a/osi-setup.md
+++ b/osi-setup.md
@@ -8,8 +8,12 @@ replace tables in the `AGENTS` schema.
 Create one required GitHub Actions secret in the repository that calls these
 workflows: `WAREHOUSE_CREDENTIALS`.
 
-Snowflake is the only supported destination today, with more destination
-support coming soon. We recommend key-pair authentication:
+Snowflake and Databricks are supported destinations. The `type` field in the
+secret selects the destination.
+
+### Snowflake
+
+We recommend key-pair authentication:
 
 **Example key-pair auth secret:**
 
@@ -30,6 +34,22 @@ private_key_passphrase: your-passphrase   # only if the key is encrypted
 **Note:**
 - `role` is optional.
 - An unencrypted key uses `-----BEGIN PRIVATE KEY-----` / `-----END PRIVATE KEY-----` markers and omits `private_key_passphrase`.
+
+### Databricks
+
+Authenticate with a personal access token against a SQL warehouse or cluster.
+
+**Example Databricks secret:**
+
+```yaml
+type: databricks
+server_hostname: dbc-12345678-90ab.cloud.databricks.com
+http_path: /sql/1.0/warehouses/abc123def456
+access_token: <your-databricks-personal-access-token>
+catalog: analytics   # optional; sets the Unity Catalog catalog for the AGENTS schema
+```
+
+**Note:** `catalog` is optional; when omitted, the connection's default catalog is used.
 
 ## Run the OSI Sync Workflow
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 license = "MIT"
 license-files = ["LICENSE"]
 authors = [{ name = "Fivetran", email = "opensource@fivetran.com" }]
-keywords = ["dbt", "osi", "lookml", "snowflake", "ai", "agents", "semantic-layer", "metadata"]
+keywords = ["dbt", "osi", "lookml", "snowflake", "databricks", "ai", "agents", "semantic-layer", "metadata"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
@@ -24,6 +24,7 @@ dependencies = [
     "cryptography>=3.1.0",
     "pyyaml>=6.0",
     "snowflake-connector-python>=3.0.0",
+    "databricks-sql-connector>=3.0.0",
 ]
 
 [project.urls]

--- a/src/agents_schema/config.py
+++ b/src/agents_schema/config.py
@@ -8,7 +8,7 @@ class ConfigError(Exception):
     """Raised when CLI arguments or environment settings are invalid."""
 
 
-SUPPORTED_WAREHOUSE_TYPES = {"snowflake"}
+SUPPORTED_WAREHOUSE_TYPES = {"snowflake", "databricks"}
 
 
 def warehouse_type(cfg: dict[str, Any]) -> str:

--- a/src/agents_schema/destinations.py
+++ b/src/agents_schema/destinations.py
@@ -18,6 +18,36 @@ AGENTS_SCHEMA = "agents"
 
 
 @dataclass(frozen=True)
+class Dialect:
+    """Warehouse-specific SQL details that differ between destinations."""
+
+    name: str
+    type_map: dict[str, str]
+    array_placeholder: str
+    emit_primary_key: bool
+    delete_via_merge: bool
+
+
+SNOWFLAKE = Dialect(
+    name="snowflake",
+    type_map={"array": "VARIANT", "boolean": "BOOLEAN", "text": "TEXT", "varchar": "VARCHAR"},
+    array_placeholder="PARSE_JSON(%s)",
+    emit_primary_key=True,
+    delete_via_merge=False,
+)
+
+# Delta: arrays are JSON text in STRING, PRIMARY KEY is informational-only (omitted),
+# and DELETE has no USING clause so deletes run as MERGE ... WHEN MATCHED THEN DELETE.
+DATABRICKS = Dialect(
+    name="databricks",
+    type_map={"array": "STRING", "boolean": "BOOLEAN", "text": "STRING", "varchar": "STRING"},
+    array_placeholder="%s",
+    emit_primary_key=False,
+    delete_via_merge=True,
+)
+
+
+@dataclass(frozen=True)
 class Column:
     name: str
     kind: str
@@ -45,23 +75,15 @@ class Destination(Protocol):
     def __exit__(self, exc_type: object, exc: object, tb: object) -> None: ...
 
 
-class SnowflakeDestination:
-    def __init__(
-        self,
-        config: dict[str, Any] | None = None,
-        *,
-        connect_kwargs: dict[str, Any] | None = None,
-    ) -> None:
-        import snowflake.connector
+class _SqlDestination:
+    """Shared MERGE/INSERT/DELETE logic over a DB-API connection and a Dialect."""
 
+    def __init__(self, con: Any, dialect: Dialect) -> None:
+        self._con = con
+        self._dialect = dialect
         self._agents_schema = AGENTS_SCHEMA
-        if connect_kwargs is None:
-            if config is None:
-                raise ConfigError("SnowflakeDestination requires config or connect_kwargs")
-            connect_kwargs = _snowflake_connect_kwargs(config)
-        self._con = snowflake.connector.connect(**connect_kwargs)
 
-    def __enter__(self) -> "SnowflakeDestination":
+    def __enter__(self) -> "_SqlDestination":
         return self
 
     def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
@@ -73,7 +95,7 @@ class SnowflakeDestination:
     def replace_table(self, table: TableSchema) -> None:
         with self._con.cursor() as cur:
             cur.execute(f"CREATE SCHEMA IF NOT EXISTS {self._agents_schema}")
-            cur.execute(_create_table_sql(table, self._agents_schema))
+            cur.execute(_create_table_sql(table, self._agents_schema, self._dialect))
 
     def upsert_rows(self, table: TableSchema, rows: Iterable[tuple[Any, ...]]) -> None:
         bind_rows = _bind_rows(table, rows)
@@ -81,9 +103,12 @@ class SnowflakeDestination:
             return
         with self._con.cursor() as cur:
             cur.execute(f"CREATE SCHEMA IF NOT EXISTS {self._agents_schema}")
-            cur.execute(_create_table_if_not_exists_sql(table, self._agents_schema))
+            cur.execute(_create_table_if_not_exists_sql(table, self._agents_schema, self._dialect))
             for batch in _batched(bind_rows, INSERT_BATCH_SIZE):
-                cur.execute(_merge_sql(table, self._agents_schema, len(batch)), _flatten(batch))
+                cur.execute(
+                    _merge_sql(table, self._agents_schema, len(batch), self._dialect),
+                    _flatten(batch),
+                )
 
     def insert_rows(self, table: TableSchema, rows: Iterable[tuple[Any, ...]]) -> None:
         bind_rows = _bind_rows(table, rows)
@@ -91,7 +116,10 @@ class SnowflakeDestination:
             return
         with self._con.cursor() as cur:
             for batch in _batched(bind_rows, INSERT_BATCH_SIZE):
-                cur.execute(_insert_sql(table, self._agents_schema, len(batch)), _flatten(batch))
+                cur.execute(
+                    _insert_sql(table, self._agents_schema, len(batch), self._dialect),
+                    _flatten(batch),
+                )
 
     def delete_rows(self, table: TableSchema, key_columns: tuple[str, ...], rows: Iterable[tuple[Any, ...]]) -> None:
         bind_rows = list(rows)
@@ -99,12 +127,44 @@ class SnowflakeDestination:
             return
         with self._con.cursor() as cur:
             cur.execute(f"CREATE SCHEMA IF NOT EXISTS {self._agents_schema}")
-            cur.execute(_create_table_if_not_exists_sql(table, self._agents_schema))
+            cur.execute(_create_table_if_not_exists_sql(table, self._agents_schema, self._dialect))
             for batch in _batched(bind_rows, INSERT_BATCH_SIZE):
                 cur.execute(
-                    _delete_sql(table, self._agents_schema, key_columns, len(batch)),
+                    _delete_sql(table, self._agents_schema, key_columns, len(batch), self._dialect),
                     _flatten(batch),
                 )
+
+
+class SnowflakeDestination(_SqlDestination):
+    def __init__(
+        self,
+        config: dict[str, Any] | None = None,
+        *,
+        connect_kwargs: dict[str, Any] | None = None,
+    ) -> None:
+        import snowflake.connector
+
+        if connect_kwargs is None:
+            if config is None:
+                raise ConfigError("SnowflakeDestination requires config or connect_kwargs")
+            connect_kwargs = _snowflake_connect_kwargs(config)
+        super().__init__(snowflake.connector.connect(**connect_kwargs), SNOWFLAKE)
+
+
+class DatabricksDestination(_SqlDestination):
+    def __init__(
+        self,
+        config: dict[str, Any] | None = None,
+        *,
+        connect_kwargs: dict[str, Any] | None = None,
+    ) -> None:
+        from databricks import sql as databricks_sql
+
+        if connect_kwargs is None:
+            if config is None:
+                raise ConfigError("DatabricksDestination requires config or connect_kwargs")
+            connect_kwargs = _databricks_connect_kwargs(config)
+        super().__init__(databricks_sql.connect(**connect_kwargs), DATABRICKS)
 
 
 def _bind_rows(table: TableSchema, rows: Iterable[tuple[Any, ...]]) -> list[tuple[Any, ...]]:
@@ -125,21 +185,34 @@ def _batched(rows: list[tuple[Any, ...]], size: int) -> Iterable[list[tuple[Any,
         yield rows[i : i + size]
 
 
-def _insert_sql(table: TableSchema, schema: str, row_count: int) -> str:
-    row_select = "SELECT " + ",".join(_placeholder(table, i) for i in range(len(table.columns)))
+def _insert_sql(table: TableSchema, schema: str, row_count: int, dialect: Dialect = SNOWFLAKE) -> str:
+    row_select = "SELECT " + ",".join(_placeholder(table, i, dialect) for i in range(len(table.columns)))
     values_sql = " UNION ALL ".join(row_select for _ in range(row_count))
     return f"INSERT INTO {_table_name(table, schema)} {values_sql}"
 
 
-def _delete_sql(table: TableSchema, schema: str, key_columns: tuple[str, ...], row_count: int) -> str:
+def _delete_sql(
+    table: TableSchema,
+    schema: str,
+    key_columns: tuple[str, ...],
+    row_count: int,
+    dialect: Dialect = SNOWFLAKE,
+) -> str:
     if not key_columns:
         raise ConfigError("delete requires at least one key column")
     source_columns = tuple(Column(name, "varchar", nullable=False) for name in key_columns)
     source_table = TableSchema(table.name, source_columns)
-    source_select = _source_select_sql(source_table, row_count)
+    source_select = _source_select_sql(source_table, row_count, dialect)
     match_sql = " AND ".join(
         f"target.{_identifier(column)} = source.{_identifier(column)}" for column in key_columns
     )
+    if dialect.delete_via_merge:
+        return (
+            f"MERGE INTO {_table_name(table, schema)} AS target\n"
+            f"USING ({source_select}) AS source\n"
+            f"ON {match_sql}\n"
+            f"WHEN MATCHED THEN DELETE"
+        )
     return (
         f"DELETE FROM {_table_name(table, schema)} AS target\n"
         f"USING ({source_select}) AS source\n"
@@ -147,10 +220,10 @@ def _delete_sql(table: TableSchema, schema: str, key_columns: tuple[str, ...], r
     )
 
 
-def _merge_sql(table: TableSchema, schema: str, row_count: int) -> str:
+def _merge_sql(table: TableSchema, schema: str, row_count: int, dialect: Dialect = SNOWFLAKE) -> str:
     if not table.primary_key:
         raise ConfigError("upsert requires a table primary key")
-    source_select = _source_select_sql(table, row_count)
+    source_select = _source_select_sql(table, row_count, dialect)
     match_sql = " AND ".join(
         f"target.{_identifier(column)} = source.{_identifier(column)}" for column in table.primary_key
     )
@@ -170,16 +243,17 @@ def _merge_sql(table: TableSchema, schema: str, row_count: int) -> str:
     )
 
 
-def _source_select_sql(table: TableSchema, row_count: int) -> str:
+def _source_select_sql(table: TableSchema, row_count: int, dialect: Dialect = SNOWFLAKE) -> str:
     row_select = "SELECT " + ", ".join(
-        f"{_placeholder(table, i)} AS {_identifier(column.name)}" for i, column in enumerate(table.columns)
+        f"{_placeholder(table, i, dialect)} AS {_identifier(column.name)}"
+        for i, column in enumerate(table.columns)
     )
     return " UNION ALL ".join(row_select for _ in range(row_count))
 
 
-def _placeholder(table: TableSchema, index: int) -> str:
+def _placeholder(table: TableSchema, index: int, dialect: Dialect = SNOWFLAKE) -> str:
     if index in table.array_indexes:
-        return "PARSE_JSON(%s)"
+        return dialect.array_placeholder
     return "%s"
 
 
@@ -191,6 +265,8 @@ def open_destination(cfg: dict[str, Any]) -> Destination:
     dest_type = warehouse_type(cfg)
     if dest_type == "snowflake":
         return SnowflakeDestination(cfg)
+    if dest_type == "databricks":
+        return DatabricksDestination(cfg)
     raise ConfigError(f"unsupported destination type: {dest_type}")
 
 
@@ -199,6 +275,31 @@ def _snowflake_connect_kwargs(cfg: dict[str, Any]) -> dict[str, Any]:
     if destination.get("type") != "snowflake":
         raise ConfigError("WAREHOUSE_CREDENTIALS.type must be snowflake")
     return _snowflake_connect_kwargs_from_secret(destination)
+
+
+def _databricks_connect_kwargs(cfg: dict[str, Any]) -> dict[str, Any]:
+    destination = warehouse_credentials_from_env()
+    if destination.get("type") != "databricks":
+        raise ConfigError("WAREHOUSE_CREDENTIALS.type must be databricks")
+    return _databricks_connect_kwargs_from_secret(destination)
+
+
+def _databricks_connect_kwargs_from_secret(destination: dict[str, Any]) -> dict[str, Any]:
+    required = ["server_hostname", "http_path"]
+    missing = [name for name in required if not destination.get(name)]
+    if not destination.get("access_token"):
+        missing.append("access_token")
+    if missing:
+        raise ConfigError("WAREHOUSE_CREDENTIALS missing keys: " + ", ".join(missing))
+
+    kwargs: dict[str, Any] = {
+        "server_hostname": destination["server_hostname"],
+        "http_path": destination["http_path"],
+        "access_token": destination["access_token"],
+    }
+    if catalog := destination.get("catalog"):
+        kwargs["catalog"] = catalog
+    return kwargs
 
 
 def warehouse_credentials_from_env() -> dict[str, Any]:
@@ -281,22 +382,24 @@ def _load_private_key(pem_bytes: bytes, passphrase: str | None) -> bytes:
     )
 
 
-def _create_table_sql(table: TableSchema, schema: str) -> str:
-    return _create_table_statement_sql("CREATE OR REPLACE TABLE", table, schema)
+def _create_table_sql(table: TableSchema, schema: str, dialect: Dialect = SNOWFLAKE) -> str:
+    return _create_table_statement_sql("CREATE OR REPLACE TABLE", table, schema, dialect)
 
 
-def _create_table_if_not_exists_sql(table: TableSchema, schema: str) -> str:
-    return _create_table_statement_sql("CREATE TABLE IF NOT EXISTS", table, schema)
+def _create_table_if_not_exists_sql(table: TableSchema, schema: str, dialect: Dialect = SNOWFLAKE) -> str:
+    return _create_table_statement_sql("CREATE TABLE IF NOT EXISTS", table, schema, dialect)
 
 
-def _create_table_statement_sql(prefix: str, table: TableSchema, schema: str) -> str:
+def _create_table_statement_sql(
+    prefix: str, table: TableSchema, schema: str, dialect: Dialect = SNOWFLAKE
+) -> str:
     definitions = []
     for column in table.columns:
-        sql = f"{column.name} {_type_sql(column.kind)}"
+        sql = f"{column.name} {_type_sql(column.kind, dialect)}"
         if not column.nullable:
             sql += " NOT NULL"
         definitions.append(sql)
-    if table.primary_key:
+    if dialect.emit_primary_key and table.primary_key:
         definitions.append(f"PRIMARY KEY ({', '.join(table.primary_key)})")
     return (
         f"{prefix} {_table_name(table, schema)} (\n    "
@@ -312,17 +415,12 @@ def _table_name(table: TableSchema, schema: str) -> str:
 
 def _identifier(identifier: str) -> str:
     if not IDENTIFIER_RE.fullmatch(identifier):
-        raise ConfigError(f"expected a simple Snowflake identifier: {identifier}")
+        raise ConfigError(f"expected a simple unquoted identifier: {identifier}")
     return identifier
 
 
-def _type_sql(kind: str) -> str:
-    if kind == "array":
-        return "VARIANT"
-    if kind == "boolean":
-        return "BOOLEAN"
-    if kind == "text":
-        return "TEXT"
-    if kind == "varchar":
-        return "VARCHAR"
-    raise ValueError(f"unsupported column kind: {kind}")
+def _type_sql(kind: str, dialect: Dialect = SNOWFLAKE) -> str:
+    try:
+        return dialect.type_map[kind]
+    except KeyError:
+        raise ValueError(f"unsupported column kind: {kind}")

--- a/tests/test_destinations.py
+++ b/tests/test_destinations.py
@@ -1,7 +1,16 @@
 import unittest
 from unittest.mock import patch
 
-from agents_schema.destinations import SnowflakeDestination, _create_table_if_not_exists_sql, _merge_sql
+from agents_schema.destinations import (
+    DATABRICKS,
+    Column,
+    DatabricksDestination,
+    SnowflakeDestination,
+    TableSchema,
+    _create_table_if_not_exists_sql,
+    _delete_sql,
+    _merge_sql,
+)
 from agents_schema.root import ROOT
 
 
@@ -42,6 +51,56 @@ class DestinationSqlTests(unittest.TestCase):
             "VALUES (source.provider, source.key, source.content)",
             sql,
         )
+
+
+ARRAY_TABLE = TableSchema(
+    "items",
+    (
+        Column("id", "varchar", nullable=False),
+        Column("tags", "array"),
+    ),
+    primary_key=("id",),
+)
+
+
+class DatabricksSqlTests(unittest.TestCase):
+    def test_databricks_destination_accepts_explicit_connection_kwargs(self):
+        with patch("databricks.sql.connect") as connect:
+            dest = DatabricksDestination(
+                connect_kwargs={"server_hostname": "h", "http_path": "p", "access_token": "t"}
+            )
+
+        connect.assert_called_once_with(server_hostname="h", http_path="p", access_token="t")
+        dest.close()
+
+    def test_create_table_maps_types_and_omits_primary_key(self):
+        sql = _create_table_if_not_exists_sql(ROOT, "agents", DATABRICKS)
+
+        self.assertEqual(
+            sql,
+            "CREATE TABLE IF NOT EXISTS agents.root (\n"
+            "    provider STRING NOT NULL,\n"
+            "    key STRING NOT NULL,\n"
+            "    content STRING NOT NULL\n"
+            ")",
+        )
+
+    def test_array_column_stored_as_string_without_parse_json(self):
+        sql = _create_table_if_not_exists_sql(ARRAY_TABLE, "agents", DATABRICKS)
+
+        self.assertIn("tags STRING", sql)
+        self.assertNotIn("VARIANT", sql)
+        merge = _merge_sql(ARRAY_TABLE, "agents", 1, DATABRICKS)
+        self.assertNotIn("PARSE_JSON", merge)
+        self.assertIn("%s AS tags", merge)
+
+    def test_delete_uses_merge_when_matched_then_delete(self):
+        sql = _delete_sql(ROOT, "agents", ("provider", "key"), 2, DATABRICKS)
+
+        self.assertIn("MERGE INTO agents.root AS target", sql)
+        self.assertIn("ON target.provider = source.provider AND target.key = source.key", sql)
+        self.assertIn("WHEN MATCHED THEN DELETE", sql)
+        self.assertFalse(sql.startswith("DELETE FROM"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds **Databricks** as a write destination alongside Snowflake.

Introduces a small SQL `Dialect` abstraction that captures the per-warehouse differences (type mapping, array/JSON handling, `PRIMARY KEY` emission, delete strategy) and factors the shared MERGE/INSERT/DELETE logic into a `_SqlDestination` base class. `SnowflakeDestination` and the new `DatabricksDestination` are thin subclasses. Snowflake SQL output is **byte-for-byte unchanged** (the dialect defaults to Snowflake everywhere).

## Changes

- `config.py`: `SUPPORTED_WAREHOUSE_TYPES = {"snowflake", "databricks"}`
- `destinations.py`: `Dialect` abstraction, `_SqlDestination` base, `DatabricksDestination` (PAT auth via `databricks-sql-connector`), and a `databricks` branch in `open_destination`
- `pyproject.toml`: add `databricks-sql-connector>=3.0.0` (core dep, mirrors `snowflake-connector-python`, so the existing `uvx` Action workflows work unchanged)
- Tests for the Databricks dialect (4 new; **23/23 pass**)
- Docs: `SPEC.md` (Databricks type column + Delta note) and the dbt/looker/osi setup guides (Databricks secret example)

## How Databricks differs from Snowflake

| Aspect | Snowflake | Databricks | Why |
|---|---|---|---|
| Arrays | `VARIANT` + `PARSE_JSON` | `STRING` (JSON text) | Portable across DBR versions |
| `varchar`/`text` | `VARCHAR`/`TEXT` | `STRING` | Delta type system |
| Primary key | emitted in DDL | omitted | Delta PKs are informational-only |
| Delete | `DELETE ... USING` | `MERGE ... WHEN MATCHED THEN DELETE` | Databricks `DELETE` has no `USING` clause |

## Decisions worth review

1. **Auth**: personal access token only (`server_hostname` + `http_path` + `access_token`, optional `catalog`). OAuth M2M can be added if wanted.
2. **Driver as core dep**: made `databricks-sql-connector` a hard dependency for zero workflow plumbing. Could instead move both drivers to optional extras (would require updating the `uvx --from` strings in the Actions).

## Test plan

- [x] `python -m pytest tests/` → 23 passed
- [x] Snowflake DDL/MERGE output unchanged
- [x] Databricks DDL maps types to `STRING`, omits `PRIMARY KEY`, delete generates a `MERGE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)