### PR TITLE
add: Support for Snowflake semantic views

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,11 +154,17 @@ agents-schema dbt --project-dir dbt_project
 agents-schema looker --lookml-dir lookml
 agents-schema osi --osi-dir osi
 agents-schema skills --skills-dir skills
+agents-schema snowflake-semantic --semantic-view ANALYTICS.FINANCE.REVENUE
 ```
 
 The CLI reads warehouse credentials from `WAREHOUSE_CREDENTIALS`. Skills default
 to `--provider user`; pass `--provider fivetran` or another reserved provider
 when publishing vendor-delivered skills.
+
+The `snowflake-semantic` command is an experimental pointer-only workflow. It
+publishes one `AGENTS.ROOT` row per `--semantic-view` value using keys such as
+`semantic_view/ANALYTICS.FINANCE.REVENUE`; the semantic view definition remains
+native to Snowflake.
 
 Skills are delivered as `AGENTS.ROOT` rows whose keys start with `skill/`:
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -99,6 +99,7 @@ lookml     explore                   One row per LookML explore. See AGENTS.LOOK
 osi        overview                  # OSI\nOpen Semantic Interchange metadata.
 osi        dataset                   One row per OSI dataset. See AGENTS.OSI_DATASET.
 osi        metric                    One row per OSI metric. See AGENTS.OSI_METRIC.
+snowflake_semantic semantic_view/... Pointer to a native Snowflake semantic view.
 skills     overview                  # Skills\nWarehouse-delivered agent skills...
 skills     skill_use                 Optional parsed skill data-use declarations.
 acme_corp  skill/refund_workflow     # Refund Workflow\nWhen a user asks about refunds...
@@ -513,6 +514,7 @@ The following provider names are reserved:
 | `lookml` | LookML metadata in `AGENTS.LOOKML_*` |
 | `osi` | OSI metadata in `AGENTS.OSI_*` |
 | `skills` | Skills extension metadata in `AGENTS.SKILL_USE` |
+| `snowflake_semantic` | Pointer rows for native Snowflake semantic views |
 | `user` | User-published skills, metadata, query recipes, or operational context |
 
 ---
@@ -534,3 +536,7 @@ The following provider names are reserved:
 | `AGENTS.OSI_FIELD` | OSI | OSI dataset fields |
 | `AGENTS.OSI_METRIC` | OSI | OSI metrics |
 | `AGENTS.OSI_RELATIONSHIP` | OSI | OSI relationships between datasets |
+
+Snowflake semantic view support is currently pointer-only. It adds rows to
+`AGENTS.ROOT` under provider `snowflake_semantic`; it does not create additional
+`AGENTS.*` tables.

--- a/src/agents_schema/cli.py
+++ b/src/agents_schema/cli.py
@@ -6,7 +6,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from . import __version__, dbt, lookml, osi, skills
+from . import __version__, dbt, lookml, osi, skills, snowflake_semantic
 from .config import ConfigError
 from .dbt_profiles import dbt_adapter_package_from_profiles_file
 from .destinations import warehouse_type_from_env
@@ -80,6 +80,18 @@ def _build_parser() -> argparse.ArgumentParser:
         help="publisher name to use for AGENTS.ROOT skill rows",
     )
 
+    snowflake_semantic_parser = sub.add_parser(
+        "snowflake-semantic",
+        help="publish Snowflake semantic view pointers into AGENTS.ROOT",
+    )
+    snowflake_semantic_parser.add_argument(
+        "--semantic-view",
+        action="append",
+        required=True,
+        dest="semantic_views",
+        help="fully qualified Snowflake semantic view name; repeat for multiple views",
+    )
+
     return parser
 
 
@@ -96,6 +108,15 @@ def main(argv: list[str] | None = None) -> int:
             cfg = _config("skills", args.skills_dir)
             cfg["metadata_connection"]["provider"] = args.provider
             skills.run(cfg)
+        elif args.source_type == "snowflake-semantic":
+            cfg = {
+                "warehouse": {"type": warehouse_type_from_env()},
+                "metadata_connection": {
+                    "type": "snowflake-semantic",
+                    "semantic_views": args.semantic_views,
+                },
+            }
+            snowflake_semantic.run(cfg)
         else:
             raise ConfigError(f"unsupported source type: {args.source_type}")
     except (ConfigError, FileNotFoundError) as e:

--- a/src/agents_schema/snowflake_semantic.py
+++ b/src/agents_schema/snowflake_semantic.py
@@ -1,0 +1,59 @@
+"""Snowflake semantic view connector: writes pointers into AGENTS.ROOT."""
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from .config import ConfigError
+from .destinations import Destination, open_destination
+from .root import ROOT
+
+__all__ = ["publish_semantic_view_pointers", "run"]
+
+PROVIDER = "snowflake_semantic"
+KEY_PREFIX = "semantic_view/"
+
+
+def run(cfg: dict) -> None:
+    semantic_views = _semantic_views_from_config(cfg)
+    with open_destination(cfg) as dest:
+        publish_semantic_view_pointers(dest, semantic_views)
+
+
+def publish_semantic_view_pointers(dest: Destination, semantic_views: Iterable[str]) -> None:
+    rows = [_root_row(name) for name in _normalize_semantic_views(semantic_views)]
+    dest.upsert_rows(ROOT, rows)
+    print(f"  snowflake-semantic: {len(rows)} semantic views")
+
+
+def _semantic_views_from_config(cfg: dict) -> list[str]:
+    return list(cfg.get("metadata_connection", {}).get("semantic_views", []))
+
+
+def _normalize_semantic_views(semantic_views: Iterable[str]) -> list[str]:
+    names = []
+    seen = set()
+    for semantic_view in semantic_views:
+        name = semantic_view.strip()
+        if not name:
+            raise ConfigError("semantic view names must not be empty")
+        if name not in seen:
+            names.append(name)
+            seen.add(name)
+    if not names:
+        raise ConfigError("at least one semantic view is required")
+    return names
+
+
+def _root_row(semantic_view: str) -> tuple[str, str, str]:
+    return (
+        PROVIDER,
+        f"{KEY_PREFIX}{semantic_view}",
+        (
+            "# Snowflake Semantic View\n\n"
+            f"Snowflake object: `{semantic_view}`\n\n"
+            "This row is a pointer to a native Snowflake semantic view. "
+            "The semantic definition lives in Snowflake. "
+            "Inspect the Snowflake object for current "
+            "dimensions, metrics, relationships, and query behavior."
+        ),
+    )

--- a/tests/test_connector_root.py
+++ b/tests/test_connector_root.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import patch
 
-from agents_schema import dbt, lookml, osi, skills
+from agents_schema import dbt, lookml, osi, skills, snowflake_semantic
 from agents_schema.skills import SkillFile
 
 
@@ -103,6 +103,25 @@ class ConnectorRootTests(unittest.TestCase):
         self.assertEqual(dest.calls[2], ("replace", "agents.skill_use"))
         self.assertEqual(dest.calls[3][0], "insert")
         self.assertEqual(dest.calls[3][1], "agents.skill_use")
+
+    def test_snowflake_semantic_run_upserts_root_pointer_rows(self):
+        dest = FakeDestination()
+        cfg = {"metadata_connection": {"semantic_views": ["ANALYTICS.FINANCE.REVENUE"]}}
+
+        with (
+            patch(
+                "agents_schema.snowflake_semantic.open_destination",
+                return_value=DestinationContext(dest),
+            ),
+            patch("builtins.print"),
+        ):
+            snowflake_semantic.run(cfg)
+
+        self.assertEqual(dest.calls[0][0], "upsert")
+        self.assertEqual(dest.calls[0][1], "agents.root")
+        self.assertEqual(dest.calls[0][2][0][0], "snowflake_semantic")
+        self.assertEqual(dest.calls[0][2][0][1], "semantic_view/ANALYTICS.FINANCE.REVENUE")
+        self.assertIn("Snowflake object: `ANALYTICS.FINANCE.REVENUE`", dest.calls[0][2][0][2])
 
     def test_publish_skill_upserts_one_root_row_and_refreshes_its_uses(self):
         dest = FakeDestination()

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -101,6 +101,32 @@ class SkillsTests(unittest.TestCase):
             }
         )
 
+    def test_cli_dispatches_snowflake_semantic_views(self):
+        with (
+            patch("agents_schema.cli.warehouse_type_from_env", return_value="snowflake"),
+            patch("agents_schema.cli.snowflake_semantic.run") as run,
+        ):
+            result = cli.main(
+                [
+                    "snowflake-semantic",
+                    "--semantic-view",
+                    "ANALYTICS.FINANCE.REVENUE",
+                    "--semantic-view",
+                    "ANALYTICS.SALES.PIPELINE",
+                ]
+            )
+
+        self.assertEqual(result, 0)
+        run.assert_called_once_with(
+            {
+                "warehouse": {"type": "snowflake"},
+                "metadata_connection": {
+                    "type": "snowflake-semantic",
+                    "semantic_views": ["ANALYTICS.FINANCE.REVENUE", "ANALYTICS.SALES.PIPELINE"],
+                },
+            }
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Adds an experimental pointer-only Snowflake semantic view source for Agents Schema. The new `snowflake-semantic` CLI command publishes one `AGENTS.ROOT` row per supplied semantic view using keys like `semantic_view/ANALYTICS.FINANCE.REVENUE`.

This keeps the semantic definition native to Snowflake while giving design partners a low-friction way to expose those objects through the existing Agents Schema discovery surface.

## Changes

- Add `src/agents_schema/snowflake_semantic.py` for ROOT-only pointer publication.
- Add `agents-schema snowflake-semantic --semantic-view ...` CLI dispatch.
- Document the experimental pointer-only workflow in README and SPEC.
- Add unit coverage for CLI dispatch and pointer row creation.

## Validation

- `uv run python -m unittest discover -s tests`
- `uv run agents-schema snowflake-semantic --help`

Note: `ruff` is not installed in this project environment, so it was not run.