### PR TITLE
fix: update repo references from fivetran to dbt-labs org

### DIFF
--- a/.github/workflows/agents-schema-dbt.yml
+++ b/.github/workflows/agents-schema-dbt.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run dbt ingestion
-        uses: fivetran/agents_schema/.github/actions/agents-schema-dbt@v0.0.9
+        uses: dbt-labs/agents_schema/.github/actions/agents-schema-dbt@v0.0.9
         with:
           dbt-project-dir: ${{ inputs.dbt-project-dir }}
           dbt-profile-name: ${{ inputs.dbt-profile-name }}

--- a/.github/workflows/agents-schema-looker.yml
+++ b/.github/workflows/agents-schema-looker.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Looker ingestion
-        uses: fivetran/agents_schema/.github/actions/agents-schema-looker@v0.0.9
+        uses: dbt-labs/agents_schema/.github/actions/agents-schema-looker@v0.0.9
         with:
           lookml-dir: ${{ inputs.lookml-dir }}
         env:

--- a/.github/workflows/agents-schema-osi.yml
+++ b/.github/workflows/agents-schema-osi.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run OSI ingestion
-        uses: fivetran/agents_schema/.github/actions/agents-schema-osi@v0.0.9
+        uses: dbt-labs/agents_schema/.github/actions/agents-schema-osi@v0.0.9
         with:
           osi-dir: ${{ inputs.osi-dir }}
         env:

--- a/.github/workflows/agents-schema-skills.yml
+++ b/.github/workflows/agents-schema-skills.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run skills ingestion
-        uses: fivetran/agents_schema/.github/actions/agents-schema-skills@v0.0.9
+        uses: dbt-labs/agents_schema/.github/actions/agents-schema-skills@v0.0.9
         with:
           skills-dir: ${{ inputs.skills-dir }}
           provider: ${{ inputs.provider }}

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ client credentials in `agents.yml` before using it.
 ```bash
 curl -fsSL --create-dirs \
   -o ~/.claude/skills/agents-schema-analyst/SKILL.md \
-  https://raw.githubusercontent.com/fivetran/agents_schema/v0.0.9/examples/skills/agents-schema-analyst/SKILL.md
+  https://raw.githubusercontent.com/dbt-labs/agents_schema/v0.0.9/examples/skills/agents-schema-analyst/SKILL.md
 ```
 
 Then ask: `/agents-schema-analyst "What is our total MRR this month?"`
@@ -110,7 +110,7 @@ Then ask: `/agents-schema-analyst "What is our total MRR this month?"`
 ```bash
 curl -fsSL --create-dirs \
   -o ~/.codex/skills/agents-schema-analyst/SKILL.md \
-  https://raw.githubusercontent.com/fivetran/agents_schema/v0.0.9/examples/skills/agents-schema-analyst/SKILL.md
+  https://raw.githubusercontent.com/dbt-labs/agents_schema/v0.0.9/examples/skills/agents-schema-analyst/SKILL.md
 ```
 
 Then ask: `$agents-schema-analyst "What is our total MRR this month?"`
@@ -197,7 +197,7 @@ source, examples, README, and spec.
 Pin exact tags in your workflows:
 
 ```yaml
-uses: fivetran/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.9
+uses: dbt-labs/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.9
 ```
 
 To upgrade, change only the tag in the `uses:` line. The current release tag is

--- a/dbt-setup.md
+++ b/dbt-setup.md
@@ -101,7 +101,7 @@ on:
 
 jobs:
   agents-schema-dbt:
-    uses: fivetran/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.9
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.9
     with:
       dbt-project-dir: dbt_project
     secrets: inherit

--- a/examples/skills/agents-schema-analyst-bigquery/SKILL.md
+++ b/examples/skills/agents-schema-analyst-bigquery/SKILL.md
@@ -20,10 +20,8 @@ that instruction in the agents dataset and follow it — not to guess a formula,
 
 - Read `project_id` and optional `location` from `agents.yml` in the working directory.
 - **Metadata dataset:** `` `<project_id>.agents` `` where `project_id` is the value from
-  `agents.yml`. If `agents_schema_name` is set in `agents.yml`, use that value instead of
-  `agents` (e.g. `` `<project_id>.my_agents` ``). Tables are referenced as
-  `` `<project_id>.agents.root` ``, `` `<project_id>.agents.osi_metric` ``, etc.
-  Substitute your actual project ID (and dataset name if customized) throughout all queries below.
+  `agents.yml`. Tables are referenced as `` `<project_id>.agents.root` ``,
+  `` `<project_id>.agents.osi_metric` ``, etc. Substitute your actual project ID throughout.
 - Execute SQL by replacing `<project_id>`, `<location>`, and `<SQL>` below and running:
   ```bash
   bq query \

--- a/examples/skills/agents-schema-analyst-bigquery/SKILL.md
+++ b/examples/skills/agents-schema-analyst-bigquery/SKILL.md
@@ -20,9 +20,10 @@ that instruction in the agents dataset and follow it — not to guess a formula,
 
 - Read `project_id` and optional `location` from `agents.yml` in the working directory.
 - **Metadata dataset:** `` `<project_id>.agents` `` where `project_id` is the value from
-  `agents.yml`. For example, if `project_id` is `my-project`, tables are referenced as
-  `` `my-project.agents`.root ``, `` `my-project.agents`.osi_metric ``, etc.
-  Substitute your actual project ID throughout all queries below.
+  `agents.yml`. If `agents_schema_name` is set in `agents.yml`, use that value instead of
+  `agents` (e.g. `` `<project_id>.my_agents` ``). Tables are referenced as
+  `` `<project_id>.agents.root` ``, `` `<project_id>.agents.osi_metric` ``, etc.
+  Substitute your actual project ID (and dataset name if customized) throughout all queries below.
 - Execute SQL by replacing `<project_id>`, `<location>`, and `<SQL>` below and running:
   ```bash
   bq query \
@@ -40,7 +41,7 @@ SQLEOF
 
 1. **Discover what metadata exists — don't assume which providers are present.**
    ```sql
-   SELECT provider, key, content FROM `<project_id>.agents`.root ORDER BY provider, key;
+   SELECT provider, key, content FROM `<project_id>.agents.root` ORDER BY provider, key;
    ```
    This lists the providers that published metadata (`osi`, `lookml`, `dbt`, or user-published) plus
    their overview/guidance rows. Only query tables for providers that actually appear here.
@@ -50,19 +51,19 @@ SQLEOF
    Substitute a keyword from the question for `<keyword>`:
    ```sql
    SELECT name, description, ai_context, expression
-   FROM `<project_id>.agents`.osi_metric
+   FROM `<project_id>.agents.osi_metric`
    WHERE LOWER(CONCAT(COALESCE(name, ''), ' ', COALESCE(description, ''), ' ', COALESCE(ai_context, '')))
          LIKE '%<keyword>%';
    ```
-   Use `` `<project_id>.agents`.lookml_measure `` (`sql`, `description`, `ai_context`) when the provider is LookML.
+   Use `` `<project_id>.agents.lookml_measure` `` (`sql`, `description`, `ai_context`) when the provider is LookML.
    **If no rows match, stop and tell the user** — do not proceed to Step 3 without a metric
    definition. Try a shorter or alternate keyword if the first search returns nothing.
 
 3. **Resolve the physical table and its rules.** Find the source table and every query caveat
    in the dataset/view metadata, and obey each `ai_context` instruction exactly:
-   - OSI: `` `<project_id>.agents`.osi_dataset `` (`source_table`, `ai_context`), `` `<project_id>.agents`.osi_field ``
-   - LookML: `` `<project_id>.agents`.lookml_view `` (`sql_table_name`), `` `<project_id>.agents`.lookml_dimension ``
-   - dbt, *only if present in root*: `` `<project_id>.agents`.dbt_model `` / `` `<project_id>.agents`.dbt_column ``
+   - OSI: `` `<project_id>.agents.osi_dataset` `` (`source_table`, `ai_context`), `` `<project_id>.agents.osi_field` ``
+   - LookML: `` `<project_id>.agents.lookml_view` `` (`sql_table_name`), `` `<project_id>.agents.lookml_dimension` ``
+   - dbt, *only if present in root*: `` `<project_id>.agents.dbt_model` `` / `` `<project_id>.agents.dbt_column` ``
      add model and column descriptions.
    Use the source table named in the metadata — not a same-named table you assume exists elsewhere.
 
@@ -99,15 +100,15 @@ Replace `<project_id>` with the actual project ID from `agents.yml` throughout.
 
 | Table | Key columns |
 |---|---|
-| `` `<project_id>.agents`.root `` | `provider`, `key`, `content` |
-| `` `<project_id>.agents`.osi_metric `` | `name`, `description`, `ai_context`, `expression` |
-| `` `<project_id>.agents`.osi_dataset `` | `name`, `source_table`, `primary_key`, `description`, `ai_context` |
-| `` `<project_id>.agents`.osi_field `` | `dataset_name`, `field_name`, `description`, `ai_context`, `is_time_dimension`, `expression` |
-| `` `<project_id>.agents`.lookml_measure `` | `view_name`, `measure_name`, `type`, `sql`, `description`, `ai_context` |
-| `` `<project_id>.agents`.lookml_view `` | `name`, `sql_table_name`, `description`, `ai_context` |
-| `` `<project_id>.agents`.lookml_dimension `` | `view_name`, `field_name`, `field_kind`, `type`, `sql`, `description`, `ai_context` |
-| `` `<project_id>.agents`.dbt_model `` | `unique_id`, `name`, `schema_name`, `description` |
-| `` `<project_id>.agents`.dbt_column `` | `model_id`, `column_name`, `data_type`, `description` |
+| `` `<project_id>.agents.root` `` | `provider`, `key`, `content` |
+| `` `<project_id>.agents.osi_metric` `` | `name`, `description`, `ai_context`, `expression` |
+| `` `<project_id>.agents.osi_dataset` `` | `name`, `source_table`, `primary_key`, `description`, `ai_context` |
+| `` `<project_id>.agents.osi_field` `` | `dataset_name`, `field_name`, `description`, `ai_context`, `is_time_dimension`, `expression` |
+| `` `<project_id>.agents.lookml_measure` `` | `view_name`, `measure_name`, `type`, `sql`, `description`, `ai_context` |
+| `` `<project_id>.agents.lookml_view` `` | `name`, `sql_table_name`, `description`, `ai_context` |
+| `` `<project_id>.agents.lookml_dimension` `` | `view_name`, `field_name`, `field_kind`, `type`, `sql`, `description`, `ai_context` |
+| `` `<project_id>.agents.dbt_model` `` | `unique_id`, `name`, `schema_name`, `description` |
+| `` `<project_id>.agents.dbt_column` `` | `model_id`, `column_name`, `data_type`, `description` |
 
 ## Common mistakes
 
@@ -116,5 +117,5 @@ Replace `<project_id>` with the actual project ID from `agents.yml` throughout.
 | Picking a plausible-looking column or table for a metric | Read the metric/dataset `ai_context` and use exactly the column, table, and filter it names. |
 | Reporting `$0` / no result for "year-to-date" | If current-year returns no rows, the data is historical — anchor to the latest year present and label it. |
 | Querying a metric from the wrong table | The dataset/view metadata names the `source_table` and any "use X not Y" caveat. Follow it. |
-| Assuming a provider's tables exist | Check `` `<project_id>.agents`.root `` first; some warehouses have only OSI, only LookML, or only dbt. |
-| Broad `INFORMATION_SCHEMA` scans to explore | Use focused `SELECT`s against the known `` `<project_id>.agents`.* `` tables. |
+| Assuming a provider's tables exist | Check `` `<project_id>.agents.root` `` first; some warehouses have only OSI, only LookML, or only dbt. |
+| Broad `INFORMATION_SCHEMA` scans to explore | Use focused `SELECT`s against the known `` `<project_id>.agents.*` `` tables. |

--- a/examples/skills/agents-schema-analyst-bigquery/SKILL.md
+++ b/examples/skills/agents-schema-analyst-bigquery/SKILL.md
@@ -10,19 +10,19 @@ argument-hint: "[business question]"
 
 ## Overview
 
-Answer the question by first reading the governed definitions in the warehouse's `AGENTS`
-metadata schema, then querying the business tables exactly as those definitions specify.
+Answer the question by first reading the governed definitions in the warehouse's `agents`
+metadata dataset, then querying the business tables exactly as those definitions specify.
 
 **Core principle: the warehouse tells you how to compute the answer. Your job is to find
-that instruction in `AGENTS.*` and follow it — not to guess a formula, table, filter, or date rule.**
+that instruction in the agents dataset and follow it — not to guess a formula, table, filter, or date rule.**
 
 ## Setup
 
 - Read `project_id` and optional `location` from `agents.yml` in the working directory.
-- **Dataset prefix (`{{AGENTS_PREFIX}}`):** backtick-quoted `project_id.agents` (or
-  `project_id.<agents_schema_name>` if `agents_schema_name` is set in `agents.yml`).
-  Example: `` `my-project.agents` ``. Use this as the dataset in every query below:
-  `` {{AGENTS_PREFIX}}.table_name ``.
+- **Metadata dataset:** `` `<project_id>.agents` `` where `project_id` is the value from
+  `agents.yml`. For example, if `project_id` is `my-project`, tables are referenced as
+  `` `my-project.agents`.root ``, `` `my-project.agents`.osi_metric ``, etc.
+  Substitute your actual project ID throughout all queries below.
 - Execute SQL by replacing `<project_id>`, `<location>`, and `<SQL>` below and running:
   ```bash
   bq query \
@@ -40,7 +40,7 @@ SQLEOF
 
 1. **Discover what metadata exists — don't assume which providers are present.**
    ```sql
-   SELECT provider, key, content FROM {{AGENTS_PREFIX}}.root ORDER BY provider, key;
+   SELECT provider, key, content FROM `<project_id>.agents`.root ORDER BY provider, key;
    ```
    This lists the providers that published metadata (`osi`, `lookml`, `dbt`, or user-published) plus
    their overview/guidance rows. Only query tables for providers that actually appear here.
@@ -50,23 +50,26 @@ SQLEOF
    Substitute a keyword from the question for `<keyword>`:
    ```sql
    SELECT name, description, ai_context, expression
-   FROM {{AGENTS_PREFIX}}.osi_metric
+   FROM `<project_id>.agents`.osi_metric
    WHERE LOWER(CONCAT(COALESCE(name, ''), ' ', COALESCE(description, ''), ' ', COALESCE(ai_context, '')))
          LIKE '%<keyword>%';
    ```
-   Use `{{AGENTS_PREFIX}}.lookml_measure` (`sql`, `description`, `ai_context`) when the provider is LookML.
-   **If no rows match, stop and tell the user** — do not proceed to Step 3 without a metric definition. Try a shorter or alternate keyword if the first search returns nothing.
+   Use `` `<project_id>.agents`.lookml_measure `` (`sql`, `description`, `ai_context`) when the provider is LookML.
+   **If no rows match, stop and tell the user** — do not proceed to Step 3 without a metric
+   definition. Try a shorter or alternate keyword if the first search returns nothing.
 
 3. **Resolve the physical table and its rules.** Find the source table and every query caveat
    in the dataset/view metadata, and obey each `ai_context` instruction exactly:
-   - OSI: `{{AGENTS_PREFIX}}.osi_dataset` (`source_table`, `ai_context`), `{{AGENTS_PREFIX}}.osi_field`
-   - LookML: `{{AGENTS_PREFIX}}.lookml_view` (`sql_table_name`), `{{AGENTS_PREFIX}}.lookml_dimension`
-   - dbt, *only if present in root*: `{{AGENTS_PREFIX}}.dbt_model` / `{{AGENTS_PREFIX}}.dbt_column` add model and
-     column descriptions.
+   - OSI: `` `<project_id>.agents`.osi_dataset `` (`source_table`, `ai_context`), `` `<project_id>.agents`.osi_field ``
+   - LookML: `` `<project_id>.agents`.lookml_view `` (`sql_table_name`), `` `<project_id>.agents`.lookml_dimension ``
+   - dbt, *only if present in root*: `` `<project_id>.agents`.dbt_model `` / `` `<project_id>.agents`.dbt_column ``
+     add model and column descriptions.
    Use the source table named in the metadata — not a same-named table you assume exists elsewhere.
 
 4. **Translate the formula to SQL.** OSI `expression` is usually plain SQL (e.g. `SUM(amount)`)
-   — use it as-is against the resolved table. **Always alias aggregate expressions** (e.g. `SUM(amount) AS value`) so `bq query --format=json` returns a named key instead of the auto-generated `f0_`. For LookML `sql`: `${TABLE}.col` → `col`;
+   — use it as-is against the resolved table. **Always alias aggregate expressions**
+   (e.g. `SUM(amount) AS value`) so `bq query --format=json` returns a named key instead of the
+   auto-generated `f0_`. For LookML `sql`: `${TABLE}.col` → `col`;
    `${other_field}` → look that field up and substitute recursively; `{% if %}…{% else %} X {% endif %}`
    → use the `{% else %}` branch.
 
@@ -81,8 +84,8 @@ SQLEOF
 
 ## Hard rules — never hard-code
 
-- Discover every metric formula, source table, filter, and date column from `AGENTS.*`. Do not
-  bake business facts into this skill, the prompt, or your reasoning.
+- Discover every metric formula, source table, filter, and date column from the agents dataset.
+  Do not bake business facts into this skill, the prompt, or your reasoning.
 - Follow `ai_context` / `description` exactly. If it says to use one column or table and not
   another, do exactly that.
 - Do not run broad `INFORMATION_SCHEMA` scans or any other schema crawl. The metadata rows tell
@@ -92,18 +95,19 @@ SQLEOF
 ## Metadata table shapes (reference)
 
 Column names are stored lowercase. A given warehouse has only the families its `root` table lists.
+Replace `<project_id>` with the actual project ID from `agents.yml` throughout.
 
 | Table | Key columns |
 |---|---|
-| `{{AGENTS_PREFIX}}.root` | `provider`, `key`, `content` |
-| `{{AGENTS_PREFIX}}.osi_metric` | `name`, `description`, `ai_context`, `expression` |
-| `{{AGENTS_PREFIX}}.osi_dataset` | `name`, `source_table`, `primary_key`, `description`, `ai_context` |
-| `{{AGENTS_PREFIX}}.osi_field` | `dataset_name`, `field_name`, `description`, `ai_context`, `is_time_dimension`, `expression` |
-| `{{AGENTS_PREFIX}}.lookml_measure` | `view_name`, `measure_name`, `type`, `sql`, `description`, `ai_context` |
-| `{{AGENTS_PREFIX}}.lookml_view` | `name`, `sql_table_name`, `description`, `ai_context` |
-| `{{AGENTS_PREFIX}}.lookml_dimension` | `view_name`, `field_name`, `field_kind`, `type`, `sql`, `description`, `ai_context` |
-| `{{AGENTS_PREFIX}}.dbt_model` | `unique_id`, `name`, `schema_name`, `description` |
-| `{{AGENTS_PREFIX}}.dbt_column` | `model_id`, `column_name`, `data_type`, `description` |
+| `` `<project_id>.agents`.root `` | `provider`, `key`, `content` |
+| `` `<project_id>.agents`.osi_metric `` | `name`, `description`, `ai_context`, `expression` |
+| `` `<project_id>.agents`.osi_dataset `` | `name`, `source_table`, `primary_key`, `description`, `ai_context` |
+| `` `<project_id>.agents`.osi_field `` | `dataset_name`, `field_name`, `description`, `ai_context`, `is_time_dimension`, `expression` |
+| `` `<project_id>.agents`.lookml_measure `` | `view_name`, `measure_name`, `type`, `sql`, `description`, `ai_context` |
+| `` `<project_id>.agents`.lookml_view `` | `name`, `sql_table_name`, `description`, `ai_context` |
+| `` `<project_id>.agents`.lookml_dimension `` | `view_name`, `field_name`, `field_kind`, `type`, `sql`, `description`, `ai_context` |
+| `` `<project_id>.agents`.dbt_model `` | `unique_id`, `name`, `schema_name`, `description` |
+| `` `<project_id>.agents`.dbt_column `` | `model_id`, `column_name`, `data_type`, `description` |
 
 ## Common mistakes
 
@@ -112,5 +116,5 @@ Column names are stored lowercase. A given warehouse has only the families its `
 | Picking a plausible-looking column or table for a metric | Read the metric/dataset `ai_context` and use exactly the column, table, and filter it names. |
 | Reporting `$0` / no result for "year-to-date" | If current-year returns no rows, the data is historical — anchor to the latest year present and label it. |
 | Querying a metric from the wrong table | The dataset/view metadata names the `source_table` and any "use X not Y" caveat. Follow it. |
-| Assuming a provider's tables exist | Check `{{AGENTS_PREFIX}}.root` first; some warehouses have only OSI, only LookML, or only dbt. |
-| Broad `INFORMATION_SCHEMA` scans to explore | Use focused `SELECT`s against the known `{{AGENTS_PREFIX}}.*` tables. |
+| Assuming a provider's tables exist | Check `` `<project_id>.agents`.root `` first; some warehouses have only OSI, only LookML, or only dbt. |
+| Broad `INFORMATION_SCHEMA` scans to explore | Use focused `SELECT`s against the known `` `<project_id>.agents`.* `` tables. |

--- a/examples/skills/agents-schema-analyst-databricks/SKILL.md
+++ b/examples/skills/agents-schema-analyst-databricks/SKILL.md
@@ -10,18 +10,18 @@ argument-hint: "[business question]"
 
 ## Overview
 
-Answer the question by first reading the governed definitions in the warehouse's `AGENTS`
+Answer the question by first reading the governed definitions in the warehouse's `agents`
 metadata schema, then querying the business tables exactly as those definitions specify.
 
 **Core principle: the warehouse tells you how to compute the answer. Your job is to find
-that instruction in `AGENTS.*` and follow it — not to guess a formula, table, filter, or date rule.**
+that instruction in the agents schema and follow it — not to guess a formula, table, filter, or date rule.**
 
 ## Setup
 
 - Read `host`, `http_path`, `token`, and `catalog` from `agents.yml` in the working directory.
-- **Schema prefix (`{{AGENTS_PREFIX}}`):** `catalog` from `agents.yml` + `.` + (`agents_schema_name`
-  lowercased from `agents.yml` if set, else `agents`). Example: `main.agents`.
-  Use this as the schema in every query below: `{{AGENTS_PREFIX}}.table_name`.
+- **Metadata schema:** `<catalog>.agents` where `catalog` is the value from `agents.yml`. For
+  example, if `catalog` is `main`, every query below uses `main.agents.root`,
+  `main.agents.osi_metric`, etc. Substitute your actual catalog name throughout.
 - Execute SQL by replacing `<SQL>` in the snippet below and running it:
   ```bash
   python3 - <<'PYEOF'
@@ -50,7 +50,7 @@ that instruction in `AGENTS.*` and follow it — not to guess a formula, table, 
 
 1. **Discover what metadata exists — don't assume which providers are present.**
    ```sql
-   SELECT provider, key, content FROM {{AGENTS_PREFIX}}.root ORDER BY provider, key;
+   SELECT provider, key, content FROM <catalog>.agents.root ORDER BY provider, key;
    ```
    This lists the providers that published metadata (`osi`, `lookml`, `dbt`, or user-published) plus
    their overview/guidance rows. Only query tables for providers that actually appear here.
@@ -60,19 +60,20 @@ that instruction in `AGENTS.*` and follow it — not to guess a formula, table, 
    Substitute a keyword from the question for `<keyword>`:
    ```sql
    SELECT name, description, ai_context, expression
-   FROM {{AGENTS_PREFIX}}.osi_metric
+   FROM <catalog>.agents.osi_metric
    WHERE LOWER(name||' '||COALESCE(description,'')||' '||COALESCE(ai_context,''))
          LIKE '%<keyword>%';
    ```
-   Use `{{AGENTS_PREFIX}}.lookml_measure` (`sql`, `description`, `ai_context`) when the provider is LookML.
-   **If no rows match, stop and tell the user** — do not proceed to Step 3 without a metric definition. Try a shorter or alternate keyword if the first search returns nothing.
+   Use `<catalog>.agents.lookml_measure` (`sql`, `description`, `ai_context`) when the provider is LookML.
+   **If no rows match, stop and tell the user** — do not proceed to Step 3 without a metric
+   definition. Try a shorter or alternate keyword if the first search returns nothing.
 
 3. **Resolve the physical table and its rules.** Find the source table and every query caveat
    in the dataset/view metadata, and obey each `ai_context` instruction exactly:
-   - OSI: `{{AGENTS_PREFIX}}.osi_dataset` (`source_table`, `ai_context`), `{{AGENTS_PREFIX}}.osi_field`
-   - LookML: `{{AGENTS_PREFIX}}.lookml_view` (`sql_table_name`), `{{AGENTS_PREFIX}}.lookml_dimension`
-   - dbt, *only if present in root*: `{{AGENTS_PREFIX}}.dbt_model` / `{{AGENTS_PREFIX}}.dbt_column` add model and
-     column descriptions.
+   - OSI: `<catalog>.agents.osi_dataset` (`source_table`, `ai_context`), `<catalog>.agents.osi_field`
+   - LookML: `<catalog>.agents.lookml_view` (`sql_table_name`), `<catalog>.agents.lookml_dimension`
+   - dbt, *only if present in root*: `<catalog>.agents.dbt_model` / `<catalog>.agents.dbt_column`
+     add model and column descriptions.
    Use the source table named in the metadata — not a same-named table you assume exists elsewhere.
 
 4. **Translate the formula to SQL.** OSI `expression` is usually plain SQL (e.g. `SUM(amount)`)
@@ -92,8 +93,8 @@ that instruction in `AGENTS.*` and follow it — not to guess a formula, table, 
 
 ## Hard rules — never hard-code
 
-- Discover every metric formula, source table, filter, and date column from `AGENTS.*`. Do not
-  bake business facts into this skill, the prompt, or your reasoning.
+- Discover every metric formula, source table, filter, and date column from the agents schema.
+  Do not bake business facts into this skill, the prompt, or your reasoning.
 - Follow `ai_context` / `description` exactly. If it says to use one column or table and not
   another, do exactly that.
 - Do not run `SHOW TABLES IN`, `DESCRIBE TABLE`, or broad schema crawls. The metadata rows tell
@@ -103,18 +104,19 @@ that instruction in `AGENTS.*` and follow it — not to guess a formula, table, 
 ## Metadata table shapes (reference)
 
 Column names are stored lowercase. A given warehouse has only the families its `root` table lists.
+Replace `<catalog>` with the actual catalog name from `agents.yml` throughout.
 
 | Table | Key columns |
 |---|---|
-| `{{AGENTS_PREFIX}}.root` | `provider`, `key`, `content` |
-| `{{AGENTS_PREFIX}}.osi_metric` | `name`, `description`, `ai_context`, `expression` |
-| `{{AGENTS_PREFIX}}.osi_dataset` | `name`, `source_table`, `primary_key`, `description`, `ai_context` |
-| `{{AGENTS_PREFIX}}.osi_field` | `dataset_name`, `field_name`, `description`, `ai_context`, `is_time_dimension`, `expression` |
-| `{{AGENTS_PREFIX}}.lookml_measure` | `view_name`, `measure_name`, `type`, `sql`, `description`, `ai_context` |
-| `{{AGENTS_PREFIX}}.lookml_view` | `name`, `sql_table_name`, `description`, `ai_context` |
-| `{{AGENTS_PREFIX}}.lookml_dimension` | `view_name`, `field_name`, `field_kind`, `type`, `sql`, `description`, `ai_context` |
-| `{{AGENTS_PREFIX}}.dbt_model` | `unique_id`, `name`, `schema_name`, `description` |
-| `{{AGENTS_PREFIX}}.dbt_column` | `model_id`, `column_name`, `data_type`, `description` |
+| `<catalog>.agents.root` | `provider`, `key`, `content` |
+| `<catalog>.agents.osi_metric` | `name`, `description`, `ai_context`, `expression` |
+| `<catalog>.agents.osi_dataset` | `name`, `source_table`, `primary_key`, `description`, `ai_context` |
+| `<catalog>.agents.osi_field` | `dataset_name`, `field_name`, `description`, `ai_context`, `is_time_dimension`, `expression` |
+| `<catalog>.agents.lookml_measure` | `view_name`, `measure_name`, `type`, `sql`, `description`, `ai_context` |
+| `<catalog>.agents.lookml_view` | `name`, `sql_table_name`, `description`, `ai_context` |
+| `<catalog>.agents.lookml_dimension` | `view_name`, `field_name`, `field_kind`, `type`, `sql`, `description`, `ai_context` |
+| `<catalog>.agents.dbt_model` | `unique_id`, `name`, `schema_name`, `description` |
+| `<catalog>.agents.dbt_column` | `model_id`, `column_name`, `data_type`, `description` |
 
 ## Common mistakes
 
@@ -123,5 +125,5 @@ Column names are stored lowercase. A given warehouse has only the families its `
 | Picking a plausible-looking column or table for a metric | Read the metric/dataset `ai_context` and use exactly the column, table, and filter it names. |
 | Reporting `$0` / no result for "year-to-date" | If current-year returns no rows, the data is historical — anchor to the latest year present and label it. |
 | Querying a metric from the wrong table | The dataset/view metadata names the `source_table` and any "use X not Y" caveat. Follow it. |
-| Assuming a provider's tables exist | Check `{{AGENTS_PREFIX}}.root` first; some warehouses have only OSI, only LookML, or only dbt. |
-| `SHOW TABLES IN` / `DESCRIBE TABLE` to explore | Use focused `SELECT`s against the known `{{AGENTS_PREFIX}}.*` tables. |
+| Assuming a provider's tables exist | Check `<catalog>.agents.root` first; some warehouses have only OSI, only LookML, or only dbt. |
+| `SHOW TABLES IN` / `DESCRIBE TABLE` to explore | Use focused `SELECT`s against the known `<catalog>.agents.*` tables. |

--- a/examples/skills/agents-schema-analyst-databricks/SKILL.md
+++ b/examples/skills/agents-schema-analyst-databricks/SKILL.md
@@ -19,10 +19,8 @@ that instruction in the agents schema and follow it — not to guess a formula, 
 ## Setup
 
 - Read `host`, `http_path`, `token`, and `catalog` from `agents.yml` in the working directory.
-- **Metadata schema:** `<catalog>.agents` where `catalog` is the value from `agents.yml`. If
-  `agents_schema_name` is set in `agents.yml`, use that value lowercased instead of `agents`
-  (e.g. `<catalog>.my_agents`). All queries below use `<catalog>.agents` — substitute your
-  actual catalog and schema name throughout.
+- **Metadata schema:** `<catalog>.agents` where `catalog` is the value from `agents.yml`.
+  All queries below use this three-part naming — substitute your actual catalog name throughout.
 - Execute SQL by replacing `<SQL>` in the snippet below and running it:
   ```bash
   python3 - <<'PYEOF'

--- a/examples/skills/agents-schema-analyst-databricks/SKILL.md
+++ b/examples/skills/agents-schema-analyst-databricks/SKILL.md
@@ -19,9 +19,10 @@ that instruction in the agents schema and follow it — not to guess a formula, 
 ## Setup
 
 - Read `host`, `http_path`, `token`, and `catalog` from `agents.yml` in the working directory.
-- **Metadata schema:** `<catalog>.agents` where `catalog` is the value from `agents.yml`. For
-  example, if `catalog` is `main`, every query below uses `main.agents.root`,
-  `main.agents.osi_metric`, etc. Substitute your actual catalog name throughout.
+- **Metadata schema:** `<catalog>.agents` where `catalog` is the value from `agents.yml`. If
+  `agents_schema_name` is set in `agents.yml`, use that value lowercased instead of `agents`
+  (e.g. `<catalog>.my_agents`). All queries below use `<catalog>.agents` — substitute your
+  actual catalog and schema name throughout.
 - Execute SQL by replacing `<SQL>` in the snippet below and running it:
   ```bash
   python3 - <<'PYEOF'
@@ -61,7 +62,7 @@ that instruction in the agents schema and follow it — not to guess a formula, 
    ```sql
    SELECT name, description, ai_context, expression
    FROM <catalog>.agents.osi_metric
-   WHERE LOWER(name||' '||COALESCE(description,'')||' '||COALESCE(ai_context,''))
+   WHERE LOWER(COALESCE(name,'')||' '||COALESCE(description,'')||' '||COALESCE(ai_context,''))
          LIKE '%<keyword>%';
    ```
    Use `<catalog>.agents.lookml_measure` (`sql`, `description`, `ai_context`) when the provider is LookML.

--- a/examples/skills/agents-schema-analyst-snowflake/SKILL.md
+++ b/examples/skills/agents-schema-analyst-snowflake/SKILL.md
@@ -42,7 +42,7 @@ that instruction in `AGENTS.*` and follow it — not to guess a formula, table, 
    ```sql
    SELECT name, description, ai_context, expression
    FROM AGENTS.osi_metric
-   WHERE LOWER(name||' '||COALESCE(description,'')||' '||COALESCE(ai_context,''))
+   WHERE LOWER(COALESCE(name,'')||' '||COALESCE(description,'')||' '||COALESCE(ai_context,''))
          LIKE '%<keyword>%';
    ```
    Use `AGENTS.lookml_measure` (`sql`, `description`, `ai_context`) when the provider is LookML.
@@ -84,6 +84,8 @@ that instruction in `AGENTS.*` and follow it — not to guess a formula, table, 
 ## Metadata table shapes (reference)
 
 A given warehouse has only the families its `root` table lists.
+Snowflake returns unquoted identifiers in UPPERCASE — business table column names will typically
+be UPPERCASE when you query them.
 
 | Table | Key columns |
 |---|---|

--- a/examples/skills/agents-schema-analyst-snowflake/SKILL.md
+++ b/examples/skills/agents-schema-analyst-snowflake/SKILL.md
@@ -22,9 +22,7 @@ that instruction in `AGENTS.*` and follow it — not to guess a formula, table, 
 - **Connection:** read `snow_cli_connection` from an `agents.yml` in the working directory if
   present. Otherwise run `snow connection list` and use the default (or the only) connection;
   if ambiguous, ask the user which connection to use.
-- **Metadata schema:** `AGENTS` (the default). If `agents_schema_name` is set in `agents.yml`,
-  use that value uppercased instead. All queries below use `AGENTS` — substitute the configured
-  name if needed.
+- **Metadata schema:** `AGENTS`. All queries below use this schema name directly.
 - Only `SELECT`. Never `INSERT`, `UPDATE`, `DELETE`, `CREATE`, or `DROP`.
 
 ## Procedure

--- a/examples/skills/agents-schema-analyst-snowflake/SKILL.md
+++ b/examples/skills/agents-schema-analyst-snowflake/SKILL.md
@@ -21,16 +21,17 @@ that instruction in `AGENTS.*` and follow it — not to guess a formula, table, 
 - Query Snowflake **read-only** with: `snow sql -c <connection> -q "<SQL>"`.
 - **Connection:** read `snow_cli_connection` from an `agents.yml` in the working directory if
   present. Otherwise run `snow connection list` and use the default (or the only) connection;
-  if it is ambiguous, ask the user which connection to use.
-- **Schema prefix (`{{AGENTS_PREFIX}}`):** use `agents_schema_name` from `agents.yml` uppercased, else `AGENTS`.
-  Use this as the schema in every query below: `{{AGENTS_PREFIX}}.table_name`.
+  if ambiguous, ask the user which connection to use.
+- **Metadata schema:** `AGENTS` (the default). If `agents_schema_name` is set in `agents.yml`,
+  use that value uppercased instead. All queries below use `AGENTS` — substitute the configured
+  name if needed.
 - Only `SELECT`. Never `INSERT`, `UPDATE`, `DELETE`, `CREATE`, or `DROP`.
 
 ## Procedure
 
 1. **Discover what metadata exists — don't assume which providers are present.**
    ```sql
-   SELECT provider, key, content FROM {{AGENTS_PREFIX}}.root ORDER BY provider, key;
+   SELECT provider, key, content FROM AGENTS.root ORDER BY provider, key;
    ```
    This lists the providers that published metadata (`osi`, `lookml`, `dbt`, or user-published) plus
    their overview/guidance rows. Only query tables for providers that actually appear here.
@@ -40,18 +41,19 @@ that instruction in `AGENTS.*` and follow it — not to guess a formula, table, 
    Substitute a keyword from the question for `<keyword>`:
    ```sql
    SELECT name, description, ai_context, expression
-   FROM {{AGENTS_PREFIX}}.osi_metric
+   FROM AGENTS.osi_metric
    WHERE LOWER(name||' '||COALESCE(description,'')||' '||COALESCE(ai_context,''))
          LIKE '%<keyword>%';
    ```
-   Use `{{AGENTS_PREFIX}}.lookml_measure` (`sql`, `description`, `ai_context`) when the provider is LookML.
-   **If no rows match, stop and tell the user** — do not proceed to Step 3 without a metric definition. Try a shorter or alternate keyword if the first search returns nothing.
+   Use `AGENTS.lookml_measure` (`sql`, `description`, `ai_context`) when the provider is LookML.
+   **If no rows match, stop and tell the user** — do not proceed to Step 3 without a metric
+   definition. Try a shorter or alternate keyword if the first search returns nothing.
 
 3. **Resolve the physical table and its rules.** Find the source table and every query caveat
    in the dataset/view metadata, and obey each `ai_context` instruction exactly:
-   - OSI: `{{AGENTS_PREFIX}}.osi_dataset` (`source_table`, `ai_context`), `{{AGENTS_PREFIX}}.osi_field`
-   - LookML: `{{AGENTS_PREFIX}}.lookml_view` (`sql_table_name`), `{{AGENTS_PREFIX}}.lookml_dimension`
-   - dbt, *only if present in root*: `{{AGENTS_PREFIX}}.dbt_model` / `{{AGENTS_PREFIX}}.dbt_column` add model and
+   - OSI: `AGENTS.osi_dataset` (`source_table`, `ai_context`), `AGENTS.osi_field`
+   - LookML: `AGENTS.lookml_view` (`sql_table_name`), `AGENTS.lookml_dimension`
+   - dbt, *only if present in root*: `AGENTS.dbt_model` / `AGENTS.dbt_column` add model and
      column descriptions.
    Use the source table named in the metadata — not a same-named table you assume exists elsewhere.
 
@@ -85,15 +87,15 @@ A given warehouse has only the families its `root` table lists.
 
 | Table | Key columns |
 |---|---|
-| `{{AGENTS_PREFIX}}.root` | `provider`, `key`, `content` |
-| `{{AGENTS_PREFIX}}.osi_metric` | `name`, `description`, `ai_context`, `expression` |
-| `{{AGENTS_PREFIX}}.osi_dataset` | `name`, `source_table`, `primary_key`, `description`, `ai_context` |
-| `{{AGENTS_PREFIX}}.osi_field` | `dataset_name`, `field_name`, `description`, `ai_context`, `is_time_dimension`, `expression` |
-| `{{AGENTS_PREFIX}}.lookml_measure` | `view_name`, `measure_name`, `type`, `sql`, `description`, `ai_context` |
-| `{{AGENTS_PREFIX}}.lookml_view` | `name`, `sql_table_name`, `description`, `ai_context` |
-| `{{AGENTS_PREFIX}}.lookml_dimension` | `view_name`, `field_name`, `field_kind`, `type`, `sql`, `description`, `ai_context` |
-| `{{AGENTS_PREFIX}}.dbt_model` | `unique_id`, `name`, `schema_name`, `description` |
-| `{{AGENTS_PREFIX}}.dbt_column` | `model_id`, `column_name`, `data_type`, `description` |
+| `AGENTS.root` | `provider`, `key`, `content` |
+| `AGENTS.osi_metric` | `name`, `description`, `ai_context`, `expression` |
+| `AGENTS.osi_dataset` | `name`, `source_table`, `primary_key`, `description`, `ai_context` |
+| `AGENTS.osi_field` | `dataset_name`, `field_name`, `description`, `ai_context`, `is_time_dimension`, `expression` |
+| `AGENTS.lookml_measure` | `view_name`, `measure_name`, `type`, `sql`, `description`, `ai_context` |
+| `AGENTS.lookml_view` | `name`, `sql_table_name`, `description`, `ai_context` |
+| `AGENTS.lookml_dimension` | `view_name`, `field_name`, `field_kind`, `type`, `sql`, `description`, `ai_context` |
+| `AGENTS.dbt_model` | `unique_id`, `name`, `schema_name`, `description` |
+| `AGENTS.dbt_column` | `model_id`, `column_name`, `data_type`, `description` |
 
 ## Common mistakes
 
@@ -102,5 +104,5 @@ A given warehouse has only the families its `root` table lists.
 | Picking a plausible-looking column or table for a metric | Read the metric/dataset `ai_context` and use exactly the column, table, and filter it names. |
 | Reporting `$0` / no result for "year-to-date" | If current-year returns no rows, the data is historical — anchor to the latest year present and label it. |
 | Querying a metric from the wrong table | The dataset/view metadata names the `source_table` and any "use X not Y" caveat. Follow it. |
-| Assuming a provider's tables exist | Check `{{AGENTS_PREFIX}}.root` first; some warehouses have only OSI, only LookML, or only dbt. |
-| `SHOW TABLES` / `GET_DDL` to explore | Use focused `SELECT`s against the known `{{AGENTS_PREFIX}}.*` tables. |
+| Assuming a provider's tables exist | Check `AGENTS.root` first; some warehouses have only OSI, only LookML, or only dbt. |
+| `SHOW TABLES` / `GET_DDL` to explore | Use focused `SELECT`s against the known `AGENTS.*` tables. |

--- a/examples/workflows/dbt-looker-osi.yml
+++ b/examples/workflows/dbt-looker-osi.yml
@@ -7,19 +7,19 @@ on:
 
 jobs:
   agents-schema-dbt:
-    uses: fivetran/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.9
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.9
     with:
       dbt-project-dir: dbt_project
     secrets: inherit
 
   agents-schema-looker:
-    uses: fivetran/agents_schema/.github/workflows/agents-schema-looker.yml@v0.0.9
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-looker.yml@v0.0.9
     with:
       lookml-dir: lookml
     secrets: inherit
 
   agents-schema-osi:
-    uses: fivetran/agents_schema/.github/workflows/agents-schema-osi.yml@v0.0.9
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-osi.yml@v0.0.9
     with:
       osi-dir: osi
     secrets: inherit

--- a/examples/workflows/dbt-looker.yml
+++ b/examples/workflows/dbt-looker.yml
@@ -7,13 +7,13 @@ on:
 
 jobs:
   agents-schema-dbt:
-    uses: fivetran/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.9
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.9
     with:
       dbt-project-dir: dbt_project
     secrets: inherit
 
   agents-schema-looker:
-    uses: fivetran/agents_schema/.github/workflows/agents-schema-looker.yml@v0.0.9
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-looker.yml@v0.0.9
     with:
       lookml-dir: lookml
     secrets: inherit

--- a/examples/workflows/dbt-with-parse.yml
+++ b/examples/workflows/dbt-with-parse.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   agents-schema-dbt:
-    uses: fivetran/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.9
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.9
     with:
       dbt-project-dir: dbt_project
       dbt-profile-name: analytics

--- a/examples/workflows/dbt.yml
+++ b/examples/workflows/dbt.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   agents-schema-dbt:
-    uses: fivetran/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.9
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.9
     with:
       dbt-project-dir: dbt_project
     secrets: inherit

--- a/examples/workflows/osi.yml
+++ b/examples/workflows/osi.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   agents-schema-osi:
-    uses: fivetran/agents_schema/.github/workflows/agents-schema-osi.yml@v0.0.9
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-osi.yml@v0.0.9
     with:
       osi-dir: osi
     secrets: inherit

--- a/examples/workflows/skills.yml
+++ b/examples/workflows/skills.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   agents-schema-skills:
-    uses: fivetran/agents_schema/.github/workflows/agents-schema-skills.yml@v0.0.9
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-skills.yml@v0.0.9
     with:
       skills-dir: skills
       provider: fivetran

--- a/looker-setup.md
+++ b/looker-setup.md
@@ -99,7 +99,7 @@ on:
 
 jobs:
   agents-schema-looker:
-    uses: fivetran/agents_schema/.github/workflows/agents-schema-looker.yml@v0.0.9
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-looker.yml@v0.0.9
     with:
       lookml-dir: lookml
     secrets: inherit

--- a/osi-setup.md
+++ b/osi-setup.md
@@ -100,7 +100,7 @@ on:
 
 jobs:
   agents-schema-osi:
-    uses: fivetran/agents_schema/.github/workflows/agents-schema-osi.yml@v0.0.9
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-osi.yml@v0.0.9
     with:
       osi-dir: osi
     secrets: inherit


### PR DESCRIPTION
## Summary
- Replaces all `fivetran/agents_schema` references with `dbt-labs/agents_schema` across workflows, examples, and docs
- Fixes GitHub Actions error where reusable workflows internally referenced the old org, causing "Repository not found: fivetran/agents_schema" errors at runtime

## Test plan
- [ ] Trigger a workflow using one of the updated reusable workflows and confirm it resolves actions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)