### PR TITLE
feat: add snowflake_semantic provider to ROOT_ENTRIES and SPEC

### DIFF
--- a/.github/actions/agents-schema-snowflake-semantic/action.yml
+++ b/.github/actions/agents-schema-snowflake-semantic/action.yml
@@ -1,0 +1,31 @@
+name: 'Agents Schema Snowflake Semantic'
+description: >
+  Publishes Snowflake semantic view pointer rows into AGENTS.ROOT.
+
+inputs:
+  semantic-views:
+    description: >
+      Newline-separated list of fully qualified Snowflake semantic view names,
+      for example: MY_DB.MY_SCHEMA.REVENUE_MODEL
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v5
+      with:
+        python-version: '3.12'
+
+    - name: Run snowflake-semantic ingestion
+      shell: bash
+      env:
+        AGENTS_SCHEMA_SEMANTIC_VIEWS: ${{ inputs.semantic-views }}
+      run: |
+        args=()
+        while IFS= read -r view; do
+          view="$(echo "$view" | xargs)"
+          [ -n "$view" ] && args+=(--semantic-view "$view")
+        done <<< "$AGENTS_SCHEMA_SEMANTIC_VIEWS"
+
+        uvx --from "agents-schema==0.0.9" \
+          agents-schema snowflake-semantic "${args[@]}"

--- a/.github/workflows/agents-schema-snowflake-semantic.yml
+++ b/.github/workflows/agents-schema-snowflake-semantic.yml
@@ -1,0 +1,29 @@
+name: Agents Schema Snowflake Semantic
+
+on:
+  workflow_call:
+    inputs:
+      semantic-views:
+        description: >
+          Newline-separated list of fully qualified Snowflake semantic view names,
+          for example: MY_DB.MY_SCHEMA.REVENUE_MODEL
+        type: string
+        required: true
+    secrets:
+      WAREHOUSE_CREDENTIALS:
+        required: true
+
+jobs:
+  ingest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Run snowflake-semantic ingestion
+        uses: dbt-labs/agents_schema/.github/actions/agents-schema-snowflake-semantic@v0.0.9
+        with:
+          semantic-views: ${{ inputs.semantic-views }}
+        env:
+          WAREHOUSE_CREDENTIALS: ${{ secrets.WAREHOUSE_CREDENTIALS }}

--- a/SPEC.md
+++ b/SPEC.md
@@ -118,6 +118,7 @@ The current package delivers one table family per metadata source:
 | LookML | `AGENTS.LOOKML_VIEW`, `AGENTS.LOOKML_DIMENSION`, `AGENTS.LOOKML_MEASURE`, `AGENTS.LOOKML_EXPLORE` |
 | OSI | `AGENTS.OSI_DATASET`, `AGENTS.OSI_FIELD`, `AGENTS.OSI_METRIC`, `AGENTS.OSI_RELATIONSHIP` |
 | Skills | `AGENTS.SKILL_USE` |
+| Snowflake Semantic | `AGENTS.ROOT` only (pointer rows; no additional tables) |
 
 Each ingestion replaces its own table family with `CREATE OR REPLACE TABLE` and then inserts the rows parsed from the source metadata.
 
@@ -464,6 +465,31 @@ CREATE OR REPLACE TABLE AGENTS.OSI_RELATIONSHIP (
 
 ---
 
+## Source: Snowflake Semantic
+
+The Snowflake Semantic ingestion publishes pointer rows into `AGENTS.ROOT` for one or more named native Snowflake semantic views. It does not create additional `AGENTS.*` tables — the semantic definition (dimensions, metrics, relationships, and query behavior) lives in Snowflake itself and should be inspected there.
+
+Each semantic view produces one row in `AGENTS.ROOT` under provider `snowflake_semantic`. The key convention is `semantic_view/<fully_qualified_name>`.
+
+The ingestion also publishes an overview row:
+
+| key | content summary |
+|---|---|
+| `overview` | Description of the `snowflake_semantic` provider and the `semantic_view/<name>` key convention. |
+| `semantic_view/<name>` | One row per configured semantic view. Content identifies the Snowflake object and directs consumers to inspect it for current metadata. |
+
+To discover all published semantic view pointers:
+
+```sql
+SELECT key, content
+FROM AGENTS.ROOT
+WHERE provider = 'snowflake_semantic'
+  AND key LIKE 'semantic_view/%'
+ORDER BY key;
+```
+
+---
+
 ## Cross-Source Queries
 
 One of the most valuable things agents can do is join across delivered source tables. For example, an agent can discover a LookML view, identify the warehouse relation it references, and compare that to dbt model names and schemas:
@@ -537,6 +563,4 @@ The following provider names are reserved:
 | `AGENTS.OSI_METRIC` | OSI | OSI metrics |
 | `AGENTS.OSI_RELATIONSHIP` | OSI | OSI relationships between datasets |
 
-Snowflake semantic view support is currently pointer-only. It adds rows to
-`AGENTS.ROOT` under provider `snowflake_semantic`; it does not create additional
-`AGENTS.*` tables.
+Snowflake Semantic writes only to `AGENTS.ROOT` under provider `snowflake_semantic` — one overview row and one `semantic_view/<name>` pointer row per configured view. See [Source: Snowflake Semantic](#source-snowflake-semantic).

--- a/src/agents_schema/root.py
+++ b/src/agents_schema/root.py
@@ -41,6 +41,9 @@ ROOT_ENTRIES = {
         ("root-convention", "Skills are rows in AGENTS.ROOT where key starts with skill/."),
         ("skill_use", "Optional parsed skill data-use declarations. See AGENTS.SKILL_USE."),
     ),
+    "snowflake_semantic": (
+        ("overview", "# Snowflake Semantic\nPointer rows for native Snowflake semantic views. Each key semantic_view/<name> in AGENTS.ROOT points to one Snowflake semantic view object. Inspect the Snowflake object for current dimensions, metrics, relationships, and query behavior."),
+    ),
 }
 
 

--- a/src/agents_schema/snowflake_semantic.py
+++ b/src/agents_schema/snowflake_semantic.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 
 from .config import ConfigError
 from .destinations import Destination, open_destination
-from .root import ROOT
+from .root import ROOT, upsert_provider_root
 
 __all__ = ["publish_semantic_view_pointers", "run"]
 
@@ -20,6 +20,7 @@ def run(cfg: dict) -> None:
 
 
 def publish_semantic_view_pointers(dest: Destination, semantic_views: Iterable[str]) -> None:
+    upsert_provider_root(dest, PROVIDER)
     rows = [_root_row(name) for name in _normalize_semantic_views(semantic_views)]
     dest.upsert_rows(ROOT, rows)
     print(f"  snowflake-semantic: {len(rows)} semantic views")

--- a/tests/test_connector_root.py
+++ b/tests/test_connector_root.py
@@ -104,7 +104,7 @@ class ConnectorRootTests(unittest.TestCase):
         self.assertEqual(dest.calls[3][0], "insert")
         self.assertEqual(dest.calls[3][1], "agents.skill_use")
 
-    def test_snowflake_semantic_run_upserts_root_pointer_rows(self):
+    def test_snowflake_semantic_run_upserts_root_overview_then_pointer_rows(self):
         dest = FakeDestination()
         cfg = {"metadata_connection": {"semantic_views": ["ANALYTICS.FINANCE.REVENUE"]}}
 
@@ -117,11 +117,18 @@ class ConnectorRootTests(unittest.TestCase):
         ):
             snowflake_semantic.run(cfg)
 
+        self.assertEqual(len(dest.calls), 2)
+        # first call: overview row
         self.assertEqual(dest.calls[0][0], "upsert")
         self.assertEqual(dest.calls[0][1], "agents.root")
-        self.assertEqual(dest.calls[0][2][0][0], "snowflake_semantic")
-        self.assertEqual(dest.calls[0][2][0][1], "semantic_view/ANALYTICS.FINANCE.REVENUE")
-        self.assertIn("Snowflake object: `ANALYTICS.FINANCE.REVENUE`", dest.calls[0][2][0][2])
+        self.assertEqual({row[0] for row in dest.calls[0][2]}, {"snowflake_semantic"})
+        self.assertEqual({row[1] for row in dest.calls[0][2]}, {"overview"})
+        # second call: per-view pointer row
+        self.assertEqual(dest.calls[1][0], "upsert")
+        self.assertEqual(dest.calls[1][1], "agents.root")
+        self.assertEqual(dest.calls[1][2][0][0], "snowflake_semantic")
+        self.assertEqual(dest.calls[1][2][0][1], "semantic_view/ANALYTICS.FINANCE.REVENUE")
+        self.assertIn("Snowflake object: `ANALYTICS.FINANCE.REVENUE`", dest.calls[1][2][0][2])
 
     def test_publish_skill_upserts_one_root_row_and_refreshes_its_uses(self):
         dest = FakeDestination()

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -40,6 +40,15 @@ class RootTests(unittest.TestCase):
         _, rows = dest.upserts[0]
         self.assertEqual({row[1] for row in rows}, {"overview", "root-convention", "skill_use"})
 
+    def test_upsert_provider_root_has_snowflake_semantic_entries(self):
+        dest = FakeDestination()
+
+        upsert_provider_root(dest, "snowflake_semantic")
+
+        _, rows = dest.upserts[0]
+        self.assertEqual({row[1] for row in rows}, {"overview"})
+        self.assertEqual({row[0] for row in rows}, {"snowflake_semantic"})
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
- Add snowflake_semantic to ROOT_ENTRIES in root.py so upsert_provider_root works for the provider and an overview row is published
- Call upsert_provider_root in snowflake_semantic.publish_semantic_view_pointers so the overview row is written before per-view pointer rows
- Add Source: Snowflake Semantic section to SPEC.md with key-convention table and example query; add provider to Delivered Source Tables
- Update test_connector_root.py to assert overview + pointer rows in order
- Add test_root.py coverage for snowflake_semantic entries