### PR TITLE
Release 0.0.10

### DIFF
--- a/.github/actions/agents-schema-dbt/action.yml
+++ b/.github/actions/agents-schema-dbt/action.yml
@@ -60,7 +60,7 @@ runs:
             adapter_args+=(--target "$DBT_TARGET")
           fi
           DBT_ADAPTER_PACKAGE="$(
-            uvx --from "agents-schema==0.0.9" \
+            uvx --from "agents-schema==0.0.10" \
               agents-schema-dbt-adapter-package "${adapter_args[@]}"
           )"
           echo "Using dbt adapter package $DBT_ADAPTER_PACKAGE from DBT_PROFILES_YML"
@@ -115,5 +115,5 @@ runs:
       env:
         AGENTS_SCHEMA_DBT_PROJECT_DIR: ${{ inputs.dbt-project-dir }}
       run: |
-        uvx --from "agents-schema==0.0.9" \
+        uvx --from "agents-schema==0.0.10" \
           agents-schema dbt --project-dir "$AGENTS_SCHEMA_DBT_PROJECT_DIR"

--- a/.github/actions/agents-schema-looker/action.yml
+++ b/.github/actions/agents-schema-looker/action.yml
@@ -19,5 +19,5 @@ runs:
       env:
         AGENTS_SCHEMA_LOOKML_DIR: ${{ inputs.lookml-dir }}
       run: |
-        uvx --from "agents-schema==0.0.9" \
+        uvx --from "agents-schema==0.0.10" \
           agents-schema looker --lookml-dir "$AGENTS_SCHEMA_LOOKML_DIR"

--- a/.github/actions/agents-schema-osi/action.yml
+++ b/.github/actions/agents-schema-osi/action.yml
@@ -19,5 +19,5 @@ runs:
       env:
         AGENTS_SCHEMA_OSI_DIR: ${{ inputs.osi-dir }}
       run: |
-        uvx --from "agents-schema==0.0.9" \
+        uvx --from "agents-schema==0.0.10" \
           agents-schema osi --osi-dir "$AGENTS_SCHEMA_OSI_DIR"

--- a/.github/actions/agents-schema-skills/action.yml
+++ b/.github/actions/agents-schema-skills/action.yml
@@ -21,7 +21,7 @@ runs:
     - name: Run skills ingestion
       shell: bash
       run: |
-        uvx --from "agents-schema==0.0.9" \
+        uvx --from "agents-schema==0.0.10" \
           agents-schema skills \
             --skills-dir "${{ inputs.skills-dir }}" \
             --provider "${{ inputs.provider }}"

--- a/.github/actions/agents-schema-snowflake-semantic/action.yml
+++ b/.github/actions/agents-schema-snowflake-semantic/action.yml
@@ -27,5 +27,5 @@ runs:
           [ -n "$view" ] && args+=(--semantic-view "$view")
         done <<< "$AGENTS_SCHEMA_SEMANTIC_VIEWS"
 
-        uvx --from "agents-schema==0.0.9" \
+        uvx --from "agents-schema==0.0.10" \
           agents-schema snowflake-semantic "${args[@]}"

--- a/.github/workflows/agents-schema-dbt.yml
+++ b/.github/workflows/agents-schema-dbt.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run dbt ingestion
-        uses: dbt-labs/agents_schema/.github/actions/agents-schema-dbt@v0.0.9
+        uses: dbt-labs/agents_schema/.github/actions/agents-schema-dbt@v0.0.10
         with:
           dbt-project-dir: ${{ inputs.dbt-project-dir }}
           dbt-profile-name: ${{ inputs.dbt-profile-name }}

--- a/.github/workflows/agents-schema-looker.yml
+++ b/.github/workflows/agents-schema-looker.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Looker ingestion
-        uses: dbt-labs/agents_schema/.github/actions/agents-schema-looker@v0.0.9
+        uses: dbt-labs/agents_schema/.github/actions/agents-schema-looker@v0.0.10
         with:
           lookml-dir: ${{ inputs.lookml-dir }}
         env:

--- a/.github/workflows/agents-schema-osi.yml
+++ b/.github/workflows/agents-schema-osi.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run OSI ingestion
-        uses: dbt-labs/agents_schema/.github/actions/agents-schema-osi@v0.0.9
+        uses: dbt-labs/agents_schema/.github/actions/agents-schema-osi@v0.0.10
         with:
           osi-dir: ${{ inputs.osi-dir }}
         env:

--- a/.github/workflows/agents-schema-skills.yml
+++ b/.github/workflows/agents-schema-skills.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run skills ingestion
-        uses: dbt-labs/agents_schema/.github/actions/agents-schema-skills@v0.0.9
+        uses: dbt-labs/agents_schema/.github/actions/agents-schema-skills@v0.0.10
         with:
           skills-dir: ${{ inputs.skills-dir }}
           provider: ${{ inputs.provider }}

--- a/.github/workflows/agents-schema-snowflake-semantic.yml
+++ b/.github/workflows/agents-schema-snowflake-semantic.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run snowflake-semantic ingestion
-        uses: dbt-labs/agents_schema/.github/actions/agents-schema-snowflake-semantic@v0.0.9
+        uses: dbt-labs/agents_schema/.github/actions/agents-schema-snowflake-semantic@v0.0.10
         with:
           semantic-views: ${{ inputs.semantic-views }}
         env:

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ credentials in `agents.yml` before using it.
 ```bash
 curl -fsSL --create-dirs \
   -o ~/.claude/skills/agents-schema-analyst/SKILL.md \
-  https://raw.githubusercontent.com/dbt-labs/agents_schema/v0.0.9/src/agents_schema/builtin_skills/agents-schema-analyst-snowflake.md
+  https://raw.githubusercontent.com/dbt-labs/agents_schema/v0.0.10/src/agents_schema/builtin_skills/agents-schema-analyst-snowflake.md
 ```
 
 Then ask: `/agents-schema-analyst "What is our total MRR this month?"`
@@ -114,12 +114,12 @@ Then ask: `/agents-schema-analyst "What is our total MRR this month?"`
 ```bash
 curl -fsSL --create-dirs \
   -o ~/.codex/skills/agents-schema-analyst/SKILL.md \
-  https://raw.githubusercontent.com/dbt-labs/agents_schema/v0.0.9/src/agents_schema/builtin_skills/agents-schema-analyst-snowflake.md
+  https://raw.githubusercontent.com/dbt-labs/agents_schema/v0.0.10/src/agents_schema/builtin_skills/agents-schema-analyst-snowflake.md
 ```
 
 Then ask: `$agents-schema-analyst "What is our total MRR this month?"`
 
-Note: the `v0.0.9` tag in these URLs is bumped as part of the normal release process
+Note: the `v0.0.10` tag in these URLs is bumped as part of the normal release process
 (`RELEASING.md`), the same as every other pinned reference in the repo.
 
 ## Why Agents Schema
@@ -211,11 +211,11 @@ source, examples, README, and spec.
 Pin exact tags in your workflows:
 
 ```yaml
-uses: dbt-labs/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.9
+uses: dbt-labs/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.10
 ```
 
 To upgrade, change only the tag in the `uses:` line. The current release tag is
-`v0.0.9`.
+`v0.0.10`.
 
 ### Specification
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -37,7 +37,7 @@ GitHub `release: published` event.
 5. Tag the release:
 
    ```bash
-   git tag v0.0.9
+   git tag v0.0.10
    git push origin main --tags
    ```
 

--- a/dbt-setup.md
+++ b/dbt-setup.md
@@ -101,7 +101,7 @@ on:
 
 jobs:
   agents-schema-dbt:
-    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.9
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.10
     with:
       dbt-project-dir: dbt_project
     secrets:

--- a/examples/workflows/dbt-looker-osi.yml
+++ b/examples/workflows/dbt-looker-osi.yml
@@ -7,21 +7,21 @@ on:
 
 jobs:
   agents-schema-dbt:
-    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.9
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.10
     with:
       dbt-project-dir: dbt_project
     secrets:
       WAREHOUSE_CREDENTIALS: ${{ secrets.WAREHOUSE_CREDENTIALS }}
 
   agents-schema-looker:
-    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-looker.yml@v0.0.9
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-looker.yml@v0.0.10
     with:
       lookml-dir: lookml
     secrets:
       WAREHOUSE_CREDENTIALS: ${{ secrets.WAREHOUSE_CREDENTIALS }}
 
   agents-schema-osi:
-    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-osi.yml@v0.0.9
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-osi.yml@v0.0.10
     with:
       osi-dir: osi
     secrets:

--- a/examples/workflows/dbt-looker.yml
+++ b/examples/workflows/dbt-looker.yml
@@ -7,14 +7,14 @@ on:
 
 jobs:
   agents-schema-dbt:
-    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.9
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.10
     with:
       dbt-project-dir: dbt_project
     secrets:
       WAREHOUSE_CREDENTIALS: ${{ secrets.WAREHOUSE_CREDENTIALS }}
 
   agents-schema-looker:
-    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-looker.yml@v0.0.9
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-looker.yml@v0.0.10
     with:
       lookml-dir: lookml
     secrets:

--- a/examples/workflows/dbt-with-parse.yml
+++ b/examples/workflows/dbt-with-parse.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   agents-schema-dbt:
-    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.9
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.10
     with:
       dbt-project-dir: dbt_project
       dbt-profile-name: analytics

--- a/examples/workflows/dbt.yml
+++ b/examples/workflows/dbt.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   agents-schema-dbt:
-    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.9
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.10
     with:
       dbt-project-dir: dbt_project
     secrets:

--- a/examples/workflows/osi.yml
+++ b/examples/workflows/osi.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   agents-schema-osi:
-    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-osi.yml@v0.0.9
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-osi.yml@v0.0.10
     with:
       osi-dir: osi
     secrets:

--- a/examples/workflows/skills.yml
+++ b/examples/workflows/skills.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   agents-schema-skills:
-    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-skills.yml@v0.0.9
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-skills.yml@v0.0.10
     with:
       skills-dir: skills
       provider: fivetran

--- a/looker-setup.md
+++ b/looker-setup.md
@@ -99,7 +99,7 @@ on:
 
 jobs:
   agents-schema-looker:
-    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-looker.yml@v0.0.9
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-looker.yml@v0.0.10
     with:
       lookml-dir: lookml
     secrets:

--- a/osi-setup.md
+++ b/osi-setup.md
@@ -100,7 +100,7 @@ on:
 
 jobs:
   agents-schema-osi:
-    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-osi.yml@v0.0.9
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-osi.yml@v0.0.10
     with:
       osi-dir: osi
     secrets:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agents-schema"
-version = "0.0.9"
+version = "0.0.10"
 description = "Populate an in-warehouse agents.* schema from dbt manifests, OSI YAML, LookML, and markdown skills."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ resolution-markers = [
 
 [[package]]
 name = "agents-schema"
-version = "0.0.9"
+version = "0.0.10"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Release 0.0.10

Version-only bump `0.0.9 → 0.0.10` across the repository, following the `Release 0.0.X` pattern (e.g. `af4598d Release 0.0.8`). No functional code changes.

### What changed
- `pyproject.toml` + `uv.lock` — package version.
- `README.md`, `RELEASING.md`, `dbt-setup.md`, `looker-setup.md`, `osi-setup.md` — pinned `@v0.0.10` refs and version notes.
- `examples/workflows/*.yml` — pinned reusable-workflow refs.
- **`.github/actions/*/action.yml`** — `uvx --from "agents-schema==0.0.10"` pins.
- **`.github/workflows/*.yml`** — internal `@v0.0.10` action pins.

The two bolded groups are the internal GitHub Actions / workflow pins that prior release commits did **not** bump; this PR includes them so every pinned reference is consistent at the release tag.

23 files, 31 insertions / 31 deletions.

### Notes
- Verified no `0.0.9` references remain in tracked files.
- `agents-schema --version` reports `0.0.10`; existing test suite passes (42 tests).
- Merge, then tag `v0.0.10` and publish the GitHub Release per `RELEASING.md` (the tag is what `publish-pypi.yml` and all the `@v0.0.10` refs resolve against).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
