### PR TITLE
add(plugin): Add Agents Schema plugin marketplace

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "agents-schema",
+  "interface": {
+    "displayName": "Agents Schema"
+  },
+  "plugins": [
+    {
+      "name": "agents-schema",
+      "source": {
+        "source": "local",
+        "path": "./plugins/agents-schema"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ available before writing or explaining queries.
   - [Sync OSI](#sync-osi)
   - [Sync Multiple Sources](#sync-multiple-sources)
 - [Query with an agent](#query-with-an-agent)
+  - [Install the Codex plugin](#install-the-codex-plugin)
 - [Why Agents Schema](#why-agents-schema)
   - [How it works](#how-it-works)
 - [Reference](#reference)
@@ -89,38 +90,30 @@ and [examples/workflows/dbt-looker-osi.yml](examples/workflows/dbt-looker-osi.ym
 
 ## Query with an agent
 
-Once `AGENTS` is populated, the `agents-schema-analyst` skill lets an AI agent answer
-questions about your warehouse — grounded in your real metric definitions from `AGENTS.*`,
-not guesses. Every CLI run also publishes the skill matching your destination into
-`AGENTS.ROOT` under `provider = skills`, `key = skill/agents-schema-analyst`, so agents already
-querying the warehouse can discover it there.
+This repository is also a Codex plugin marketplace. Its `agents-schema` plugin installs two
+independent skills before Codex connects to your warehouse:
 
-To install it into a local agent, pick the variant for your warehouse
-(`snowflake`, `databricks`, or `bigquery`) and configure the matching local SQL client
-credentials in `agents.yml` before using it.
+- `connect-warehouse` configures and verifies Snowflake, BigQuery, or Databricks access.
+- `agents-schema-search` discovers warehouse metadata through `AGENTS.ROOT` after a connection
+  is available.
 
-**Claude Code** (Snowflake shown; swap the `-snowflake` suffix for your warehouse)
+These plugin skills are local agent tooling. They do not replace the existing destination-matched
+`agents-schema-analyst` row that the ingestion CLI publishes into `AGENTS.ROOT`; that warehouse-side
+behavior remains unchanged. Teams can also continue publishing their own warehouse-delivered
+Markdown skills through the skills provider.
 
-```bash
-curl -fsSL --create-dirs \
-  -o ~/.claude/skills/agents-schema-analyst/SKILL.md \
-  https://raw.githubusercontent.com/dbt-labs/agents_schema/v0.0.10/src/agents_schema/builtin_skills/agents-schema-analyst-snowflake.md
-```
+### Install the Codex plugin
 
-Then ask: `/agents-schema-analyst "What is our total MRR this month?"`
-
-**Codex** (Snowflake shown; swap the `-snowflake` suffix for your warehouse)
+Add this GitHub repository as a marketplace and install the plugin:
 
 ```bash
-curl -fsSL --create-dirs \
-  -o ~/.codex/skills/agents-schema-analyst/SKILL.md \
-  https://raw.githubusercontent.com/dbt-labs/agents_schema/v0.0.10/src/agents_schema/builtin_skills/agents-schema-analyst-snowflake.md
+codex plugin marketplace add dbt-labs/agents_schema
+codex plugin add agents-schema@agents-schema
 ```
 
-Then ask: `$agents-schema-analyst "What is our total MRR this month?"`
-
-Note: the `v0.0.10` tag in these URLs is bumped as part of the normal release process
-(`RELEASING.md`), the same as every other pinned reference in the repo.
+Start a new Codex task after installation so the new skills are available. The marketplace lives
+at `.agents/plugins/marketplace.json`, and additional Agents Schema plugins can be added under
+`plugins/` over time.
 
 ## Why Agents Schema
 

--- a/plugins/agents-schema/.codex-plugin/plugin.json
+++ b/plugins/agents-schema/.codex-plugin/plugin.json
@@ -1,0 +1,26 @@
+{
+  "name": "agents-schema",
+  "version": "0.1.0",
+  "description": "Connect to a data warehouse and discover metadata through its AGENTS schema.",
+  "author": {
+    "name": "dbt Labs",
+    "url": "https://github.com/dbt-labs"
+  },
+  "homepage": "https://github.com/dbt-labs/agents_schema",
+  "repository": "https://github.com/dbt-labs/agents_schema",
+  "license": "MIT",
+  "keywords": ["agents-schema", "snowflake", "bigquery", "databricks", "metadata"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Agents Schema",
+    "shortDescription": "Connect to warehouses and search Agents Schema.",
+    "longDescription": "Connect Codex to Snowflake, BigQuery, or Databricks, then use the warehouse-native AGENTS schema to discover provider metadata.",
+    "developerName": "dbt Labs",
+    "category": "Data & Analytics",
+    "capabilities": ["Read"],
+    "defaultPrompt": [
+      "Help me connect to my data warehouse.",
+      "Use Agents Schema to answer this warehouse question."
+    ]
+  }
+}

--- a/plugins/agents-schema/skills/agents-schema-search/SKILL.md
+++ b/plugins/agents-schema/skills/agents-schema-search/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: agents-schema-search
+description: >
+  Use when answering questions about data in a warehouse (BigQuery, Snowflake, etc.) and you have direct SQL access (CLI, driver, or console). Discover metadata and run knowledge search through the warehouse-native AGENTS schema instead of INFORMATION_SCHEMA.
+---
+
+# Answering warehouse-data questions via the AGENTS schema
+
+Before answering a warehouse-data question, read the warehouse AGENTS schema.
+
+AGENTS.ROOT is the entry point for the warehouse-native Agents Schema. It tells
+AI agents which providers have published metadata and how to use their
+provider-specific tables.
+
+Use AGENTS as the warehouse metadata and discovery surface. Treat it like an
+agent-oriented alternative to INFORMATION_SCHEMA: inspect AGENTS.ROOT and the
+provider-specific AGENTS.* tables instead of querying INFORMATION_SCHEMA
+directly. Only fall back to INFORMATION_SCHEMA when the AGENTS content
+explicitly says to verify live metadata, or when required metadata is missing
+from AGENTS.
+
+Use your connection's SQL dialect (e.g. GoogleSQL on BigQuery), and quote
+schema and table identifiers using that dialect. Run read-only SELECT
+statements only.
+
+Required first query:
+
+```sql
+SELECT * FROM AGENTS.ROOT ORDER BY provider, key;
+```
+
+Then follow the provider guidance returned in the `content` column.
+
+If no rows are returned, or the AGENTS schema or the AGENTS.ROOT table is not
+found, tell the user that their AGENTS schema is not set up yet.

--- a/plugins/agents-schema/skills/agents-schema-search/agents/openai.yaml
+++ b/plugins/agents-schema/skills/agents-schema-search/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Agents Schema Search"
+  short_description: "Discover warehouse metadata via AGENTS.ROOT"
+  default_prompt: "Use $agents-schema-search to discover metadata for this warehouse question."

--- a/plugins/agents-schema/skills/connect-warehouse/SKILL.md
+++ b/plugins/agents-schema/skills/connect-warehouse/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: connect-warehouse
+description: Connect Codex to Snowflake, BigQuery, or Databricks so it can run SQL. Use when warehouse access is missing, authentication or connection selection is required, or before using a warehouse-data skill such as agents-schema-search.
+---
+
+# Connect Warehouse
+
+Identify the warehouse from the user's request, repository configuration, or available clients.
+If the warehouse is ambiguous, ask which one they use.
+
+Read exactly one connection guide before proceeding:
+
+- Snowflake: [references/snowflake.md](references/snowflake.md)
+- BigQuery: [references/bigquery.md](references/bigquery.md)
+- Databricks: [references/databricks.md](references/databricks.md)
+
+Help the user configure the client, select the intended connection, and verify it with the guide's
+test query. Do not ask the user to paste credentials or tokens into chat. Stop after connection
+verification unless the user also asked to run a query or invoke another skill.

--- a/plugins/agents-schema/skills/connect-warehouse/agents/openai.yaml
+++ b/plugins/agents-schema/skills/connect-warehouse/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Connect Warehouse"
+  short_description: "Configure Snowflake, BigQuery, or Databricks"
+  default_prompt: "Use $connect-warehouse to help me connect to my data warehouse."

--- a/plugins/agents-schema/skills/connect-warehouse/references/bigquery.md
+++ b/plugins/agents-schema/skills/connect-warehouse/references/bigquery.md
@@ -1,0 +1,28 @@
+# BigQuery
+
+Use the `bq` CLI.
+
+1. Read `project_id` and optional `location` from `agents.yml` when present. Otherwise ask the
+   user which Google Cloud project and location to use.
+2. If authentication is missing, help the user authenticate the Google Cloud CLI.
+3. Verify the connection:
+
+   ```bash
+   bq query \
+     --project_id="<project_id>" \
+     --location="<location>" \
+     --use_legacy_sql=false \
+     'SELECT 1'
+   ```
+
+Omit `--location` when it is not configured. Run later SQL by replacing `<SQL>` below:
+
+```bash
+bq query \
+  --project_id="<project_id>" \
+  --location="<location>" \
+  --use_legacy_sql=false \
+  --format=json <<'SQLEOF'
+<SQL>
+SQLEOF
+```

--- a/plugins/agents-schema/skills/connect-warehouse/references/databricks.md
+++ b/plugins/agents-schema/skills/connect-warehouse/references/databricks.md
@@ -1,0 +1,31 @@
+# Databricks
+
+Use the Databricks SQL Connector for Python.
+
+1. Read `host`, `http_path`, `token`, and `catalog` from `agents.yml`. Ask the user to add any
+   missing value without pasting secrets into chat.
+2. Install `databricks-sql-connector` when `databricks.sql` is unavailable.
+3. Verify the connection by replacing `<SQL>` with `SELECT 1`:
+
+   ```bash
+   python3 - <<'PYEOF'
+   import databricks.sql
+   import json
+   import yaml
+
+   cfg = yaml.safe_load(open("agents.yml"))
+   with databricks.sql.connect(
+       server_hostname=cfg["host"],
+       http_path=cfg["http_path"],
+       access_token=cfg["token"],
+       catalog=cfg["catalog"],
+   ) as connection:
+       with connection.cursor() as cursor:
+           cursor.execute("""
+   <SQL>
+           """)
+           columns = [column[0] for column in cursor.description]
+           rows = [dict(zip(columns, row)) for row in cursor.fetchall()]
+           print(json.dumps(rows, indent=2, default=str))
+   PYEOF
+   ```

--- a/plugins/agents-schema/skills/connect-warehouse/references/snowflake.md
+++ b/plugins/agents-schema/skills/connect-warehouse/references/snowflake.md
@@ -1,0 +1,19 @@
+# Snowflake
+
+Use the Snowflake CLI (`snow`).
+
+1. If `agents.yml` contains `snow_cli_connection`, use that named connection.
+2. Otherwise, run `snow connection list`. Use the default connection or the only configured
+   connection. If several connections remain possible, ask the user which one to use.
+3. If no connection exists, help the user create one with `snow connection add`.
+4. Verify the connection:
+
+   ```bash
+   snow sql -c <connection> -q "SELECT CURRENT_USER(), CURRENT_DATABASE(), CURRENT_SCHEMA()"
+   ```
+
+Run later SQL with:
+
+```bash
+snow sql -c <connection> -q "<SQL>"
+```

--- a/tests/test_plugin_marketplace.py
+++ b/tests/test_plugin_marketplace.py
@@ -1,0 +1,40 @@
+import json
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MARKETPLACE_PATH = REPO_ROOT / ".agents" / "plugins" / "marketplace.json"
+PLUGIN_ROOT = REPO_ROOT / "plugins" / "agents-schema"
+
+
+class PluginMarketplaceTests(unittest.TestCase):
+    def test_marketplace_installs_agents_schema_plugin(self):
+        marketplace = json.loads(MARKETPLACE_PATH.read_text())
+
+        self.assertEqual(marketplace["name"], "agents-schema")
+        self.assertEqual(len(marketplace["plugins"]), 1)
+        entry = marketplace["plugins"][0]
+        self.assertEqual(entry["name"], "agents-schema")
+        self.assertEqual(entry["source"], {"source": "local", "path": "./plugins/agents-schema"})
+        self.assertEqual(
+            entry["policy"],
+            {"installation": "AVAILABLE", "authentication": "ON_INSTALL"},
+        )
+
+    def test_plugin_contains_schema_search_and_connection_skills(self):
+        manifest = json.loads((PLUGIN_ROOT / ".codex-plugin" / "plugin.json").read_text())
+        skill_root = PLUGIN_ROOT / manifest["skills"]
+        skill_names = {path.parent.name for path in skill_root.glob("*/SKILL.md")}
+
+        self.assertEqual(skill_names, {"agents-schema-search", "connect-warehouse"})
+        schema_skill = (skill_root / "agents-schema-search" / "SKILL.md").read_text()
+        self.assertIn("SELECT * FROM AGENTS.ROOT ORDER BY provider, key;", schema_skill)
+        connection_references = {
+            path.stem for path in (skill_root / "connect-warehouse" / "references").glob("*.md")
+        }
+        self.assertEqual(connection_references, {"snowflake", "bigquery", "databricks"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- add a repository marketplace at `.agents/plugins/marketplace.json`
- add an installable `agents-schema` plugin containing exactly two local skills:
  - `agents-schema-search`, copied verbatim from the requested gist
  - `connect-warehouse`, with focused Snowflake, BigQuery, and Databricks connection references
- document direct installation from the GitHub repository
- add tests for the marketplace entry and plugin skill structure

## Why

The warehouse connection and minimal Agents Schema search guidance are useful as local precursors before an agent queries a warehouse. Packaging them as a plugin lets this repository serve as the marketplace for these and future Agents Schema plugins.

## Existing behavior

Ingestion-time built-in skill publication is unchanged. The destination-matched `agents-schema-analyst` skill continues to be published into `AGENTS.ROOT`, and teams can continue publishing their own warehouse-delivered Markdown skills through the existing skills provider.

## User impact

Users can install both local skills with:

```bash
codex plugin marketplace add dbt-labs/agents_schema
codex plugin add agents-schema@agents-schema
```

## Validation

- `uv run python -m unittest discover -s tests` (44 tests passed)
- both skill packages pass `quick_validate.py`
- the plugin passes `validate_plugin.py`
- `agents-schema-search/SKILL.md` matches gist `30405ae4ff41fc340e8ccd73dab75bcc` byte-for-byte
- `git diff --check`
