### PR TITLE
feat: add Omni ingestion connector

### DIFF
--- a/.github/actions/agents-schema-omni/action.yml
+++ b/.github/actions/agents-schema-omni/action.yml
@@ -1,0 +1,23 @@
+name: 'Agents Schema Omni'
+description: >
+  Ingests Omni metadata into AGENTS.OMNI_* tables.
+
+inputs:
+  omni-dir:
+    description: 'Path to an Omni connection directory containing *.view.yaml and *.topic.yaml files'
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v5
+      with:
+        python-version: '3.12'
+
+    - name: Run Omni ingestion
+      shell: bash
+      env:
+        AGENTS_SCHEMA_OMNI_DIR: ${{ inputs.omni-dir }}
+      run: |
+        uvx --from "agents-schema==0.0.9" \
+          agents-schema omni --omni-dir "$AGENTS_SCHEMA_OMNI_DIR"

--- a/.github/workflows/agents-schema-omni.yml
+++ b/.github/workflows/agents-schema-omni.yml
@@ -1,0 +1,30 @@
+name: Agents Schema Omni
+
+on:
+  workflow_call:
+    inputs:
+      omni-dir:
+        description: 'Path to an Omni connection directory containing *.view.yaml and *.topic.yaml files'
+        type: string
+        required: true
+    secrets:
+      WAREHOUSE_CREDENTIALS:
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  ingest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Run Omni ingestion
+        uses: dbt-labs/agents_schema/.github/actions/agents-schema-omni@v0.0.9
+        with:
+          omni-dir: ${{ inputs.omni-dir }}
+        env:
+          WAREHOUSE_CREDENTIALS: ${{ secrets.WAREHOUSE_CREDENTIALS }}

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ repo already produces `target/manifest.json`, the workflow only needs the dbt
 project path and your warehouse credentials.
 
 After the first run, your warehouse has queryable metadata tables such as
-`AGENTS.DBT_MODEL`, `AGENTS.LOOKML_VIEW`, or `AGENTS.OSI_DATASET`. Agents can
+`AGENTS.DBT_MODEL`, `AGENTS.LOOKML_VIEW`, `AGENTS.OMNI_VIEW`, or `AGENTS.OSI_DATASET`. Agents can
 use those tables to understand which models and semantic objects exist, how
 they are documented, how they relate to the warehouse, and what context is
 available before writing or explaining queries.
@@ -31,6 +31,7 @@ available before writing or explaining queries.
 - [Guides](#guides)
   - [Sync dbt](#sync-dbt)
   - [Sync Looker](#sync-looker)
+  - [Sync Omni](#sync-omni)
   - [Sync OSI](#sync-osi)
   - [Sync Multiple Sources](#sync-multiple-sources)
 - [Query with an agent](#query-with-an-agent)
@@ -51,6 +52,7 @@ Supported sources:
 
 - dbt
 - Looker
+- Omni
 - OSI
 - Markdown skills
 
@@ -77,6 +79,11 @@ or an existing `target/manifest.json`.
 
 Use [Looker Setup Guide](looker-setup.md) when your repository contains LookML
 files.
+
+### Sync Omni
+
+Use [Omni Setup Guide](omni-setup.md) when your repository contains Omni YAML
+files synced via the Omni Git integration.
 
 ### Sync OSI
 
@@ -173,7 +180,7 @@ source-specific workflows.
 
 1. A workflow in your repository invokes one of this repo's workflows.
 2. The workflow checks out your repository and reads source metadata such as
-   dbt artifacts, LookML files, or OSI YAML files.
+   dbt artifacts, LookML files, Omni YAML files, or OSI YAML files.
 3. The workflow runs the `agents-schema` CLI at the pinned release tag.
 4. The CLI writes normalized metadata and warehouse-delivered skills into the
    warehouse under the `AGENTS` schema.
@@ -189,6 +196,7 @@ The GitHub Actions call the CLI with explicit source arguments:
 ```bash
 agents-schema dbt --project-dir dbt_project
 agents-schema looker --lookml-dir lookml
+agents-schema omni --omni-dir "omni/My Connection"
 agents-schema osi --osi-dir osi
 agents-schema skills --skills-dir skills
 agents-schema snowflake-semantic --semantic-view ANALYTICS.FINANCE.REVENUE

--- a/examples/workflows/omni.yml
+++ b/examples/workflows/omni.yml
@@ -1,0 +1,14 @@
+name: Agents Schema Omni
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+jobs:
+  agents-schema-omni:
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-omni.yml@v0.0.9
+    with:
+      omni-dir: omni/My Connection
+    secrets:
+      WAREHOUSE_CREDENTIALS: ${{ secrets.WAREHOUSE_CREDENTIALS }}

--- a/omni-setup.md
+++ b/omni-setup.md
@@ -1,0 +1,116 @@
+# Omni Setup
+
+## Prerequisites
+
+Configure the `WAREHOUSE_CREDENTIALS` GitHub Actions secret for your destination
+warehouse. Copy the YAML for your destination, fill in your values, and save it
+as the `WAREHOUSE_CREDENTIALS` GitHub Actions secret in the repository that
+calls this workflow.
+
+<details>
+<summary>Snowflake setup</summary>
+
+We recommend key-pair authentication:
+
+```yaml
+type: snowflake
+account: abc123
+user: AGENTS_SCHEMA_BOT
+warehouse: COMPUTE_WH
+database: ANALYTICS
+role: TRANSFORMER
+private_key_pem: |
+  -----BEGIN ENCRYPTED PRIVATE KEY-----
+  MIIEvQIBADANBgkqh...
+  -----END ENCRYPTED PRIVATE KEY-----
+private_key_passphrase: your-passphrase   # only if the key is encrypted
+```
+
+`role` is optional. An unencrypted key uses `-----BEGIN PRIVATE KEY-----` /
+`-----END PRIVATE KEY-----` markers and omits `private_key_passphrase`.
+
+Password auth is also supported by replacing the private key fields with:
+
+```yaml
+password: your-password
+```
+
+</details>
+
+<details>
+<summary>Databricks setup</summary>
+
+Use a SQL warehouse HTTP path and a personal access token:
+
+```yaml
+type: databricks
+host: dbc-abc123.cloud.databricks.com
+http_path: /sql/1.0/warehouses/abc123
+catalog: main
+token: your-personal-access-token
+```
+
+The token needs permission to create and write tables in the `agents` schema
+within the configured catalog.
+
+</details>
+
+<details>
+<summary>BigQuery setup</summary>
+
+Use the destination project plus a service account JSON object:
+
+```yaml
+type: bigquery
+project_id: my-gcp-project
+location: US
+credentials_json:
+  type: service_account
+  project_id: service-account-project
+  private_key_id: ...
+  private_key: |
+    -----BEGIN PRIVATE KEY-----
+    ...
+    -----END PRIVATE KEY-----
+  client_email: agents-schema@my-gcp-project.iam.gserviceaccount.com
+  client_id: ...
+  auth_uri: https://accounts.google.com/o/oauth2/auth
+  token_uri: https://oauth2.googleapis.com/token
+  auth_provider_x509_cert_url: https://www.googleapis.com/oauth2/v1/certs
+  client_x509_cert_url: ...
+```
+
+`location` is optional. The service account needs permission to create datasets
+and create, load, query, update, and delete tables in the destination project.
+
+</details>
+
+## Run the Omni Sync Workflow
+
+Use the Omni workflow when the repository contains Omni YAML files synced via
+the Omni Git integration:
+
+```yaml
+name: Agents Schema Omni
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+jobs:
+  agents-schema-omni:
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-omni.yml@v0.0.9
+    with:
+      omni-dir: omni/My Connection
+    secrets:
+      WAREHOUSE_CREDENTIALS: ${{ secrets.WAREHOUSE_CREDENTIALS }}
+```
+
+`omni-dir` is required — set it to the connection-level directory that contains
+your `*.view.yaml` and `*.topic.yaml` files. Omni's Git integration syncs files
+under a per-connection subdirectory (e.g. `omni/Snowflake (Production)/`); point
+`omni-dir` at that subdirectory, not the repository root.
+
+These jobs do not need to depend on each other unless your repository has its
+own ordering requirement.

--- a/src/agents_schema/builtin_skills/agents-schema-analyst-bigquery.md
+++ b/src/agents_schema/builtin_skills/agents-schema-analyst-bigquery.md
@@ -54,6 +54,7 @@ SQLEOF
          LIKE '%<keyword>%';
    ```
    Use `` `<project_id>.agents.lookml_measure` `` (`sql`, `description`, `ai_context`) when the provider is LookML.
+   Use `` `<project_id>.agents.omni_measure` `` (`sql`, `description`) when the provider is Omni.
    **If no rows match, stop and tell the user** — do not proceed to Step 3 without a metric
    definition. Try a shorter or alternate keyword if the first search returns nothing.
 
@@ -61,6 +62,8 @@ SQLEOF
    in the dataset/view metadata, and obey each `ai_context` instruction exactly:
    - OSI: `` `<project_id>.agents.osi_dataset` `` (`source_table`, `ai_context`), `` `<project_id>.agents.osi_field` ``
    - LookML: `` `<project_id>.agents.lookml_view` `` (`sql_table_name`), `` `<project_id>.agents.lookml_dimension` ``
+   - Omni: `` `<project_id>.agents.omni_view` `` (`schema`, `table_name`, `description`), `` `<project_id>.agents.omni_dimension` ``;
+     use `` `<project_id>.agents.omni_topic_join` `` to understand which views are reachable within a topic.
    - dbt, *only if present in root*: `` `<project_id>.agents.dbt_model` `` / `` `<project_id>.agents.dbt_column` ``
      add model and column descriptions.
    Use the source table named in the metadata — not a same-named table you assume exists elsewhere.
@@ -70,7 +73,8 @@ SQLEOF
    (e.g. `SUM(amount) AS value`) so `bq query --format=json` returns a named key instead of the
    auto-generated `f0_`. For LookML `sql`: `${TABLE}.col` → `col`;
    `${other_field}` → look that field up and substitute recursively; `{% if %}…{% else %} X {% endif %}`
-   → use the `{% else %}` branch.
+   → use the `{% else %}` branch. For Omni `sql`: the value is a quoted column reference
+   (e.g. `'"AMOUNT"'`) — strip the outer quotes and use the inner identifier directly.
 
 5. **Pick the time grain from metadata.** Use the time dimension the metadata marks
    (`osi_field.is_time_dimension`, or a LookML `dimension_group`). For "current"/snapshot
@@ -105,6 +109,11 @@ Replace `<project_id>` with the actual project ID from `agents.yml` throughout.
 | `` `<project_id>.agents.lookml_measure` `` | `view_name`, `measure_name`, `type`, `sql`, `description`, `ai_context` |
 | `` `<project_id>.agents.lookml_view` `` | `name`, `sql_table_name`, `description`, `ai_context` |
 | `` `<project_id>.agents.lookml_dimension` `` | `view_name`, `field_name`, `field_kind`, `type`, `sql`, `description`, `ai_context` |
+| `` `<project_id>.agents.omni_measure` `` | `view_name`, `measure_name`, `aggregate_type`, `sql`, `description` |
+| `` `<project_id>.agents.omni_view` `` | `view_name`, `schema`, `table_name`, `description` |
+| `` `<project_id>.agents.omni_dimension` `` | `view_name`, `field_name`, `sql`, `description` |
+| `` `<project_id>.agents.omni_topic` `` | `topic_name`, `base_view`, `label`, `group_label`, `description`, `ai_context` |
+| `` `<project_id>.agents.omni_topic_join` `` | `topic_name`, `from_view`, `to_view` |
 | `` `<project_id>.agents.dbt_model` `` | `unique_id`, `name`, `schema_name`, `description` |
 | `` `<project_id>.agents.dbt_column` `` | `model_id`, `column_name`, `data_type`, `description` |
 

--- a/src/agents_schema/builtin_skills/agents-schema-analyst-databricks.md
+++ b/src/agents_schema/builtin_skills/agents-schema-analyst-databricks.md
@@ -64,6 +64,7 @@ that instruction in the agents schema and follow it — not to guess a formula, 
          LIKE '%<keyword>%';
    ```
    Use `<catalog>.agents.lookml_measure` (`sql`, `description`, `ai_context`) when the provider is LookML.
+   Use `<catalog>.agents.omni_measure` (`sql`, `description`) when the provider is Omni.
    **If no rows match, stop and tell the user** — do not proceed to Step 3 without a metric
    definition. Try a shorter or alternate keyword if the first search returns nothing.
 
@@ -71,6 +72,8 @@ that instruction in the agents schema and follow it — not to guess a formula, 
    in the dataset/view metadata, and obey each `ai_context` instruction exactly:
    - OSI: `<catalog>.agents.osi_dataset` (`source_table`, `ai_context`), `<catalog>.agents.osi_field`
    - LookML: `<catalog>.agents.lookml_view` (`sql_table_name`), `<catalog>.agents.lookml_dimension`
+   - Omni: `<catalog>.agents.omni_view` (`schema`, `table_name`, `description`), `<catalog>.agents.omni_dimension`;
+     use `<catalog>.agents.omni_topic_join` to understand which views are reachable within a topic.
    - dbt, *only if present in root*: `<catalog>.agents.dbt_model` / `<catalog>.agents.dbt_column`
      add model and column descriptions.
    Use the source table named in the metadata — not a same-named table you assume exists elsewhere.
@@ -78,7 +81,8 @@ that instruction in the agents schema and follow it — not to guess a formula, 
 4. **Translate the formula to SQL.** OSI `expression` is usually plain SQL (e.g. `SUM(amount)`)
    — use it as-is against the resolved table. For LookML `sql`: `${TABLE}.col` → `col`;
    `${other_field}` → look that field up and substitute recursively; `{% if %}…{% else %} X {% endif %}`
-   → use the `{% else %}` branch.
+   → use the `{% else %}` branch. For Omni `sql`: the value is a quoted column reference
+   (e.g. `'"AMOUNT"'`) — strip the outer quotes and use the inner identifier directly.
 
 5. **Pick the time grain from metadata.** Use the time dimension the metadata marks
    (`osi_field.is_time_dimension`, or a LookML `dimension_group`). For "current"/snapshot
@@ -114,6 +118,11 @@ Replace `<catalog>` with the actual catalog name from `agents.yml` throughout.
 | `<catalog>.agents.lookml_measure` | `view_name`, `measure_name`, `type`, `sql`, `description`, `ai_context` |
 | `<catalog>.agents.lookml_view` | `name`, `sql_table_name`, `description`, `ai_context` |
 | `<catalog>.agents.lookml_dimension` | `view_name`, `field_name`, `field_kind`, `type`, `sql`, `description`, `ai_context` |
+| `<catalog>.agents.omni_measure` | `view_name`, `measure_name`, `aggregate_type`, `sql`, `description` |
+| `<catalog>.agents.omni_view` | `view_name`, `schema`, `table_name`, `description` |
+| `<catalog>.agents.omni_dimension` | `view_name`, `field_name`, `sql`, `description` |
+| `<catalog>.agents.omni_topic` | `topic_name`, `base_view`, `label`, `group_label`, `description`, `ai_context` |
+| `<catalog>.agents.omni_topic_join` | `topic_name`, `from_view`, `to_view` |
 | `<catalog>.agents.dbt_model` | `unique_id`, `name`, `schema_name`, `description` |
 | `<catalog>.agents.dbt_column` | `model_id`, `column_name`, `data_type`, `description` |
 

--- a/src/agents_schema/builtin_skills/agents-schema-analyst-snowflake.md
+++ b/src/agents_schema/builtin_skills/agents-schema-analyst-snowflake.md
@@ -44,6 +44,7 @@ that instruction in `AGENTS.*` and follow it — not to guess a formula, table, 
          LIKE '%<keyword>%';
    ```
    Use `AGENTS.lookml_measure` (`sql`, `description`, `ai_context`) when the provider is LookML.
+   Use `AGENTS.omni_measure` (`sql`, `description`) when the provider is Omni.
    **If no rows match, stop and tell the user** — do not proceed to Step 3 without a metric
    definition. Try a shorter or alternate keyword if the first search returns nothing.
 
@@ -51,6 +52,8 @@ that instruction in `AGENTS.*` and follow it — not to guess a formula, table, 
    in the dataset/view metadata, and obey each `ai_context` instruction exactly:
    - OSI: `AGENTS.osi_dataset` (`source_table`, `ai_context`), `AGENTS.osi_field`
    - LookML: `AGENTS.lookml_view` (`sql_table_name`), `AGENTS.lookml_dimension`
+   - Omni: `AGENTS.omni_view` (`schema`, `table_name`, `description`), `AGENTS.omni_dimension`;
+     use `AGENTS.omni_topic_join` to understand which views are reachable within a topic.
    - dbt, *only if present in root*: `AGENTS.dbt_model` / `AGENTS.dbt_column` add model and
      column descriptions.
    Use the source table named in the metadata — not a same-named table you assume exists elsewhere.
@@ -58,7 +61,8 @@ that instruction in `AGENTS.*` and follow it — not to guess a formula, table, 
 4. **Translate the formula to SQL.** OSI `expression` is usually plain SQL (e.g. `SUM(amount)`)
    — use it as-is against the resolved table. For LookML `sql`: `${TABLE}.col` → `col`;
    `${other_field}` → look that field up and substitute recursively; `{% if %}…{% else %} X {% endif %}`
-   → use the `{% else %}` branch.
+   → use the `{% else %}` branch. For Omni `sql`: the value is a quoted column reference
+   (e.g. `'"AMOUNT"'`) — strip the outer quotes and use the inner identifier directly.
 
 5. **Pick the time grain from metadata.** Use the time dimension the metadata marks
    (`osi_field.is_time_dimension`, or a LookML `dimension_group`). For "current"/snapshot
@@ -94,6 +98,11 @@ be UPPERCASE when you query them.
 | `AGENTS.lookml_measure` | `view_name`, `measure_name`, `type`, `sql`, `description`, `ai_context` |
 | `AGENTS.lookml_view` | `name`, `sql_table_name`, `description`, `ai_context` |
 | `AGENTS.lookml_dimension` | `view_name`, `field_name`, `field_kind`, `type`, `sql`, `description`, `ai_context` |
+| `AGENTS.omni_measure` | `view_name`, `measure_name`, `aggregate_type`, `sql`, `description` |
+| `AGENTS.omni_view` | `view_name`, `schema`, `table_name`, `description` |
+| `AGENTS.omni_dimension` | `view_name`, `field_name`, `sql`, `description` |
+| `AGENTS.omni_topic` | `topic_name`, `base_view`, `label`, `group_label`, `description`, `ai_context` |
+| `AGENTS.omni_topic_join` | `topic_name`, `from_view`, `to_view` |
 | `AGENTS.dbt_model` | `unique_id`, `name`, `schema_name`, `description` |
 | `AGENTS.dbt_column` | `model_id`, `column_name`, `data_type`, `description` |
 

--- a/src/agents_schema/cli.py
+++ b/src/agents_schema/cli.py
@@ -6,7 +6,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from . import __version__, dbt, lookml, osi, skills, snowflake_semantic
+from . import __version__, dbt, lookml, omni, osi, skills, snowflake_semantic
 from .config import ConfigError
 from .dbt_profiles import dbt_adapter_package_from_profiles_file
 from .destinations import warehouse_type_from_env
@@ -51,6 +51,17 @@ def _build_parser() -> argparse.ArgumentParser:
         required=True,
         type=Path,
         help="path to a Looker project or directory containing *.lkml files",
+    )
+
+    omni_parser = sub.add_parser(
+        "omni",
+        help="ingest Omni YAML files into AGENTS.OMNI_*",
+    )
+    omni_parser.add_argument(
+        "--omni-dir",
+        required=True,
+        type=Path,
+        help="path to an Omni connection directory containing *.view.yaml and *.topic.yaml files",
     )
 
     osi_parser = sub.add_parser(
@@ -102,6 +113,8 @@ def main(argv: list[str] | None = None) -> int:
             dbt.run(_config("dbt", args.project_dir))
         elif args.source_type == "looker":
             lookml.run(_config("looker", args.lookml_dir))
+        elif args.source_type == "omni":
+            omni.run(_config("omni", args.omni_dir))
         elif args.source_type == "osi":
             osi.run(_config("osi", args.osi_dir))
         elif args.source_type == "skills":

--- a/src/agents_schema/omni.py
+++ b/src/agents_schema/omni.py
@@ -1,0 +1,217 @@
+"""Omni connector: writes agents.omni_* from Omni YAML files."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+from .destinations import Column, Destination, TableSchema, open_destination
+from .root import upsert_provider_root
+
+__all__ = ["run"]
+
+_REF_RE = re.compile(r"#\s*Reference this view as\s+(\S+)")
+
+OMNI_VIEW = TableSchema(
+    "agents.omni_view",
+    (
+        Column("view_name", "varchar", nullable=False),
+        Column("schema", "varchar"),
+        Column("table_name", "varchar"),
+        Column("label", "varchar"),
+        Column("description", "text"),
+        Column("file_path", "varchar"),
+    ),
+    primary_key=("view_name",),
+)
+OMNI_DIMENSION = TableSchema(
+    "agents.omni_dimension",
+    (
+        Column("view_name", "varchar", nullable=False),
+        Column("field_name", "varchar", nullable=False),
+        Column("label", "varchar"),
+        Column("sql", "text"),
+        Column("format", "varchar"),
+        Column("description", "text"),
+        Column("primary_key", "boolean"),
+    ),
+    primary_key=("view_name", "field_name"),
+)
+OMNI_MEASURE = TableSchema(
+    "agents.omni_measure",
+    (
+        Column("view_name", "varchar", nullable=False),
+        Column("measure_name", "varchar", nullable=False),
+        Column("label", "varchar"),
+        Column("aggregate_type", "varchar"),
+        Column("sql", "text"),
+        Column("description", "text"),
+    ),
+    primary_key=("view_name", "measure_name"),
+)
+OMNI_TOPIC = TableSchema(
+    "agents.omni_topic",
+    (
+        Column("topic_name", "varchar", nullable=False),
+        Column("base_view", "varchar"),
+        Column("label", "varchar"),
+        Column("group_label", "varchar"),
+        Column("description", "text"),
+        Column("ai_context", "text"),
+        Column("file_path", "varchar"),
+    ),
+    primary_key=("topic_name",),
+)
+OMNI_TOPIC_JOIN = TableSchema(
+    "agents.omni_topic_join",
+    (
+        Column("topic_name", "varchar", nullable=False),
+        Column("from_view", "varchar", nullable=False),
+        Column("to_view", "varchar", nullable=False),
+    ),
+    primary_key=("topic_name", "from_view", "to_view"),
+)
+
+
+def run(cfg: dict) -> None:
+    omni_dir = Path(cfg["metadata_connection"]["path"])
+    if not omni_dir.is_dir():
+        raise FileNotFoundError(f"omni directory not found: {omni_dir}")
+    with open_destination(cfg) as dest:
+        upsert_provider_root(dest, "omni")
+        _create_tables(dest)
+        _ingest(dest, omni_dir)
+
+
+def _create_tables(dest: Destination) -> None:
+    dest.replace_table(OMNI_VIEW)
+    dest.replace_table(OMNI_DIMENSION)
+    dest.replace_table(OMNI_MEASURE)
+    dest.replace_table(OMNI_TOPIC)
+    dest.replace_table(OMNI_TOPIC_JOIN)
+
+
+def _view_name_from_file(path: Path, base_dir: Path) -> str:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    for line in text.splitlines()[:5]:
+        m = _REF_RE.search(line)
+        if m:
+            return m.group(1)
+    # Fallback: {schema}__{stem} derived from path
+    rel = path.relative_to(base_dir)
+    parts = rel.parts
+    name = parts[-1]
+    if name.endswith(".view.yaml"):
+        name = name[: -len(".view.yaml")]
+    if len(parts) > 1:
+        return f"{parts[-2]}__{name}"
+    return name
+
+
+def _topic_name_from_file(path: Path) -> str:
+    name = path.name
+    if name.endswith(".topic.yaml"):
+        return name[: -len(".topic.yaml")]
+    return name
+
+
+def _collect_joins(joins: dict, parent: str, seen: set, result: list) -> None:
+    for to_view, children in joins.items():
+        edge = (parent, to_view)
+        if edge not in seen:
+            seen.add(edge)
+            result.append(edge)
+        if isinstance(children, dict) and children:
+            _collect_joins(children, to_view, seen, result)
+
+
+def _ingest(dest: Destination, omni_dir: Path) -> None:
+    views, dimensions, measures = [], [], []
+    topics, topic_joins = [], []
+
+    for path in sorted(omni_dir.glob("**/*.view.yaml")):
+        rel = str(path.relative_to(omni_dir))
+        raw = path.read_text(encoding="utf-8", errors="replace")
+        view_name = _view_name_from_file(path, omni_dir)
+        try:
+            doc = yaml.safe_load(raw) or {}
+        except yaml.YAMLError:
+            continue
+
+        views.append((
+            view_name,
+            doc.get("schema"),
+            doc.get("table_name"),
+            doc.get("label"),
+            doc.get("description"),
+            rel,
+        ))
+
+        for field_name, field in (doc.get("dimensions") or {}).items():
+            if not isinstance(field, dict):
+                field = {}
+            dimensions.append((
+                view_name,
+                field_name,
+                field.get("label"),
+                field.get("sql"),
+                field.get("format"),
+                field.get("description"),
+                bool(field.get("primary_key")),
+            ))
+
+        for measure_name, measure in (doc.get("measures") or {}).items():
+            if not isinstance(measure, dict):
+                measure = {}
+            measures.append((
+                view_name,
+                measure_name,
+                measure.get("label"),
+                measure.get("aggregate_type"),
+                measure.get("sql"),
+                measure.get("description"),
+            ))
+
+    for path in sorted(omni_dir.glob("**/*.topic.yaml")):
+        rel = str(path.relative_to(omni_dir))
+        topic_name = _topic_name_from_file(path)
+        try:
+            doc = yaml.safe_load(path.read_text(encoding="utf-8", errors="replace")) or {}
+        except yaml.YAMLError:
+            continue
+
+        base_view = doc.get("base_view") or ""
+        topics.append((
+            topic_name,
+            base_view,
+            doc.get("label"),
+            doc.get("group_label"),
+            doc.get("description"),
+            doc.get("ai_context"),
+            rel,
+        ))
+
+        joins_dict = doc.get("joins")
+        if isinstance(joins_dict, dict) and joins_dict:
+            seen: set[tuple[str, str]] = set()
+            edges: list[tuple[str, str]] = []
+            _collect_joins(joins_dict, base_view, seen, edges)
+            for from_view, to_view in edges:
+                topic_joins.append((topic_name, from_view, to_view))
+
+    if views:
+        dest.insert_rows(OMNI_VIEW, views)
+    if dimensions:
+        dest.insert_rows(OMNI_DIMENSION, dimensions)
+    if measures:
+        dest.insert_rows(OMNI_MEASURE, measures)
+    if topics:
+        dest.insert_rows(OMNI_TOPIC, topics)
+    if topic_joins:
+        dest.insert_rows(OMNI_TOPIC_JOIN, topic_joins)
+
+    print(
+        f"  omni:     {len(views)} views, {len(dimensions)} dimensions, "
+        f"{len(measures)} measures, {len(topics)} topics, {len(topic_joins)} joins"
+    )

--- a/src/agents_schema/root.py
+++ b/src/agents_schema/root.py
@@ -29,6 +29,14 @@ ROOT_ENTRIES = {
         ("measure", "One row per LookML measure. See AGENTS.LOOKML_MEASURE."),
         ("explore", "One row per LookML explore. See AGENTS.LOOKML_EXPLORE."),
     ),
+    "omni": (
+        ("overview", "# Omni\nSemantic metadata parsed from Omni YAML files."),
+        ("view", "One row per Omni view. See AGENTS.OMNI_VIEW."),
+        ("dimension", "One row per Omni dimension. See AGENTS.OMNI_DIMENSION."),
+        ("measure", "One row per Omni measure. See AGENTS.OMNI_MEASURE."),
+        ("topic", "One row per Omni topic. See AGENTS.OMNI_TOPIC."),
+        ("topic_join", "One row per join edge within a topic. See AGENTS.OMNI_TOPIC_JOIN."),
+    ),
     "osi": (
         ("overview", "# OSI\nOpen Semantic Interchange metadata parsed from *.osi.yaml files."),
         ("dataset", "One row per OSI dataset. See AGENTS.OSI_DATASET."),

--- a/tests/test_connector_root.py
+++ b/tests/test_connector_root.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import patch
 
-from agents_schema import dbt, lookml, osi, skills, snowflake_semantic
+from agents_schema import dbt, lookml, omni, osi, skills, snowflake_semantic
 from agents_schema.skills import SkillFile
 
 
@@ -65,6 +65,21 @@ class ConnectorRootTests(unittest.TestCase):
         self.assertEqual(dest.calls[0][0], "upsert")
         self.assertEqual({row[0] for row in dest.calls[0][2]}, {"lookml"})
         self.assertEqual([call[0] for call in dest.calls[1:5]], ["replace", "replace", "replace", "replace"])
+
+    def test_omni_run_upserts_root_before_source_tables(self):
+        dest = FakeDestination()
+        cfg = {"metadata_connection": {"path": "."}}
+
+        with (
+            patch("agents_schema.omni.open_destination", return_value=DestinationContext(dest)),
+            patch("agents_schema.omni._ingest"),
+            patch("builtins.print"),
+        ):
+            omni.run(cfg)
+
+        self.assertEqual(dest.calls[0][0], "upsert")
+        self.assertEqual({row[0] for row in dest.calls[0][2]}, {"omni"})
+        self.assertEqual([call[0] for call in dest.calls[1:6]], ["replace", "replace", "replace", "replace", "replace"])
 
     def test_osi_run_upserts_root_before_source_tables(self):
         dest = FakeDestination()

--- a/tests/test_omni.py
+++ b/tests/test_omni.py
@@ -1,0 +1,253 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from agents_schema.omni import (
+    _collect_joins,
+    _topic_name_from_file,
+    _view_name_from_file,
+    _ingest,
+    OMNI_VIEW,
+    OMNI_DIMENSION,
+    OMNI_MEASURE,
+    OMNI_TOPIC,
+    OMNI_TOPIC_JOIN,
+)
+
+
+class FakeDestination:
+    def __init__(self):
+        self.calls = []
+
+    def replace_table(self, table):
+        self.calls.append(("replace", table.name))
+
+    def insert_rows(self, table, rows):
+        self.calls.append(("insert", table.name, list(rows)))
+
+    def upsert_rows(self, table, rows):
+        self.calls.append(("upsert", table.name, list(rows)))
+
+
+VIEW_YAML = """\
+# Reference this view as schema_a__view_foo
+schema: schema_a
+table_name: VIEW_FOO
+label: Foo View
+description: A test view.
+
+dimensions:
+  record_id:
+    sql: '"RECORD_ID"'
+    description: The record identifier.
+    format: ID
+    primary_key: true
+  title:
+    sql: '"TITLE"'
+    label: Record Title
+
+measures:
+  count:
+    aggregate_type: count
+  total_value:
+    aggregate_type: sum
+    sql: '"VALUE"'
+    description: Sum of values.
+"""
+
+VIEW_YAML_NO_COMMENT = """\
+schema: schema_b
+table_name: VIEW_BAR
+dimensions:
+  id:
+    sql: '"ID"'
+"""
+
+TOPIC_YAML = """\
+base_view: schema_a__fact_alpha
+base_view_label: Alpha
+label: Alpha Topic
+group_label: Group One
+description: Alpha topic data.
+ai_context: Use for alpha analysis.
+
+joins:
+  schema_a__dim_beta: {}
+  schema_a__dim_gamma:
+    schema_a__dim_delta: {}
+
+views:
+  schema_a__fact_alpha:
+    display_order: 0
+  schema_a__dim_beta:
+    display_order: 1
+"""
+
+TOPIC_YAML_NO_JOINS = """\
+base_view: schema_a__fact_epsilon
+label: Epsilon
+joins: {}
+"""
+
+
+class ViewNameTests(unittest.TestCase):
+    def test_view_name_from_comment(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            p = base / "view_foo.view.yaml"
+            p.write_text(VIEW_YAML)
+            self.assertEqual(_view_name_from_file(p, base), "schema_a__view_foo")
+
+    def test_view_name_fallback_with_schema_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            schema_dir = base / "omni_dbt"
+            schema_dir.mkdir()
+            p = schema_dir / "stg_foo.view.yaml"
+            p.write_text(VIEW_YAML_NO_COMMENT)
+            self.assertEqual(_view_name_from_file(p, base), "omni_dbt__stg_foo")
+
+    def test_view_name_fallback_at_root(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            p = base / "stg_foo.view.yaml"
+            p.write_text(VIEW_YAML_NO_COMMENT)
+            self.assertEqual(_view_name_from_file(p, base), "stg_foo")
+
+
+class TopicNameTests(unittest.TestCase):
+    def test_topic_name_strips_suffix(self):
+        p = Path("omni_dbt__fct_orders.topic.yaml")
+        self.assertEqual(_topic_name_from_file(p), "omni_dbt__fct_orders")
+
+    def test_topic_name_with_spaces(self):
+        p = Path("Exec MBR Metrics: FY27 (Quarter).topic.yaml")
+        self.assertEqual(_topic_name_from_file(p), "Exec MBR Metrics: FY27 (Quarter)")
+
+
+class CollectJoinsTests(unittest.TestCase):
+    def test_direct_joins(self):
+        joins = {"view_b": {}, "view_c": {}}
+        seen, result = set(), []
+        _collect_joins(joins, "view_a", seen, result)
+        self.assertIn(("view_a", "view_b"), result)
+        self.assertIn(("view_a", "view_c"), result)
+
+    def test_nested_joins(self):
+        joins = {"view_b": {"view_c": {}}}
+        seen, result = set(), []
+        _collect_joins(joins, "view_a", seen, result)
+        self.assertEqual(result, [("view_a", "view_b"), ("view_b", "view_c")])
+
+    def test_deeply_nested_joins(self):
+        joins = {"view_b": {"view_c": {"view_d": {}}}}
+        seen, result = set(), []
+        _collect_joins(joins, "view_a", seen, result)
+        self.assertEqual(result, [
+            ("view_a", "view_b"),
+            ("view_b", "view_c"),
+            ("view_c", "view_d"),
+        ])
+
+    def test_no_duplicate_edges(self):
+        joins = {"view_b": {}, "view_c": {}}
+        seen = {("view_a", "view_b")}
+        result = []
+        _collect_joins(joins, "view_a", seen, result)
+        self.assertEqual(result, [("view_a", "view_c")])
+
+    def test_empty_joins(self):
+        seen, result = set(), []
+        _collect_joins({}, "view_a", seen, result)
+        self.assertEqual(result, [])
+
+
+class IngestTests(unittest.TestCase):
+    def _write_files(self, tmp):
+        base = Path(tmp)
+        (base / "view_foo.view.yaml").write_text(VIEW_YAML)
+        (base / "alpha.topic.yaml").write_text(TOPIC_YAML)
+        (base / "epsilon.topic.yaml").write_text(TOPIC_YAML_NO_JOINS)
+        return base
+
+    def _inserted(self, dest, table_name):
+        return next(
+            (rows for op, name, rows in dest.calls if op == "insert" and name == table_name),
+            None,
+        )
+
+    def test_view_row_columns(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            dest = FakeDestination()
+            _ingest(dest, self._write_files(tmp))
+            rows = self._inserted(dest, OMNI_VIEW.name)
+            self.assertIsNotNone(rows)
+            row = rows[0]
+            self.assertEqual(row[0], "schema_a__view_foo")  # view_name
+            self.assertEqual(row[1], "schema_a")            # schema
+            self.assertEqual(row[2], "VIEW_FOO")            # table_name
+            self.assertEqual(row[3], "Foo View")            # label
+            self.assertIn("test view", row[4])              # description
+
+    def test_dimension_rows(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            dest = FakeDestination()
+            _ingest(dest, self._write_files(tmp))
+            rows = self._inserted(dest, OMNI_DIMENSION.name)
+            self.assertIsNotNone(rows)
+            by_name = {r[1]: r for r in rows}
+            self.assertIn("record_id", by_name)
+            self.assertIn("title", by_name)
+            rec = by_name["record_id"]
+            self.assertEqual(rec[0], "schema_a__view_foo")  # view_name
+            self.assertEqual(rec[4], "ID")                  # format
+            self.assertTrue(rec[6])                         # primary_key
+
+    def test_measure_rows(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            dest = FakeDestination()
+            _ingest(dest, self._write_files(tmp))
+            rows = self._inserted(dest, OMNI_MEASURE.name)
+            self.assertIsNotNone(rows)
+            by_name = {r[1]: r for r in rows}
+            self.assertIn("count", by_name)
+            self.assertIn("total_value", by_name)
+            self.assertEqual(by_name["count"][3], "count")          # aggregate_type
+            self.assertEqual(by_name["total_value"][5], "Sum of values.")  # description
+
+    def test_topic_row(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            dest = FakeDestination()
+            _ingest(dest, self._write_files(tmp))
+            rows = self._inserted(dest, OMNI_TOPIC.name)
+            self.assertIsNotNone(rows)
+            by_name = {r[0]: r for r in rows}
+            self.assertIn("alpha", by_name)
+            row = by_name["alpha"]
+            self.assertEqual(row[1], "schema_a__fact_alpha")  # base_view
+            self.assertEqual(row[2], "Alpha Topic")           # label
+            self.assertEqual(row[3], "Group One")             # group_label
+            self.assertEqual(row[5], "Use for alpha analysis.")  # ai_context
+
+    def test_topic_join_rows(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            dest = FakeDestination()
+            _ingest(dest, self._write_files(tmp))
+            rows = self._inserted(dest, OMNI_TOPIC_JOIN.name)
+            self.assertIsNotNone(rows)
+            edges = {(r[1], r[2]) for r in rows if r[0] == "alpha"}
+            self.assertIn(("schema_a__fact_alpha", "schema_a__dim_beta"), edges)
+            self.assertIn(("schema_a__fact_alpha", "schema_a__dim_gamma"), edges)
+            self.assertIn(("schema_a__dim_gamma", "schema_a__dim_delta"), edges)
+
+    def test_empty_joins_produces_no_join_rows(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            dest = FakeDestination()
+            _ingest(dest, self._write_files(tmp))
+            rows = self._inserted(dest, OMNI_TOPIC_JOIN.name)
+            epsilon_joins = [r for r in (rows or []) if r[0] == "epsilon"]
+            self.assertEqual(epsilon_joins, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -32,6 +32,22 @@ class RootTests(unittest.TestCase):
         _, rows = dest.upserts[0]
         self.assertEqual({row[1] for row in rows}, {"overview", "dataset", "field", "metric", "relationship"})
 
+    def test_upsert_provider_root_has_lookml_entries(self):
+        dest = FakeDestination()
+
+        upsert_provider_root(dest, "lookml")
+
+        _, rows = dest.upserts[0]
+        self.assertEqual({row[1] for row in rows}, {"overview", "view", "dimension", "measure", "explore"})
+
+    def test_upsert_provider_root_has_omni_entries(self):
+        dest = FakeDestination()
+
+        upsert_provider_root(dest, "omni")
+
+        _, rows = dest.upserts[0]
+        self.assertEqual({row[1] for row in rows}, {"overview", "view", "dimension", "measure", "topic", "topic_join"})
+
     def test_upsert_provider_root_has_skills_entries(self):
         dest = FakeDestination()
 


### PR DESCRIPTION
## Summary
- Adds an `agents-schema omni` subcommand that parses Omni YAML files (`*.view.yaml`, `*.topic.yaml`) from a connection directory and writes to five new tables: `OMNI_VIEW`, `OMNI_DIMENSION`, `OMNI_MEASURE`, `OMNI_TOPIC`, and `OMNI_TOPIC_JOIN`.
- `OMNI_TOPIC_JOIN` captures the full recursive join topology within each topic, not just membership, so agents can reason about view reachability and join depth.
- Adds the Omni setup guide (`omni-setup.md`), README updates, an example workflow, and Omni-specific guidance in the built-in analyst skills (`src/agents_schema/builtin_skills/agents-schema-analyst-*.md`).

This replaces #25, which was closed because `main` had since merged the plugin-marketplace restructuring (#34) that moved the analyst skill files. This branch is rebased cleanly on top of that — same scope as #25, no leftover conflicts.