### PR TITLE
Bump to 0.0.11 and fix omni/sigma version drift

### DIFF
--- a/.github/actions/agents-schema-dbt/action.yml
+++ b/.github/actions/agents-schema-dbt/action.yml
@@ -60,7 +60,7 @@ runs:
             adapter_args+=(--target "$DBT_TARGET")
           fi
           DBT_ADAPTER_PACKAGE="$(
-            uvx --from "agents-schema==0.0.10" \
+            uvx --from "agents-schema==0.0.11" \
               agents-schema-dbt-adapter-package "${adapter_args[@]}"
           )"
           echo "Using dbt adapter package $DBT_ADAPTER_PACKAGE from DBT_PROFILES_YML"
@@ -115,5 +115,5 @@ runs:
       env:
         AGENTS_SCHEMA_DBT_PROJECT_DIR: ${{ inputs.dbt-project-dir }}
       run: |
-        uvx --from "agents-schema==0.0.10" \
+        uvx --from "agents-schema==0.0.11" \
           agents-schema dbt --project-dir "$AGENTS_SCHEMA_DBT_PROJECT_DIR"

--- a/.github/actions/agents-schema-looker/action.yml
+++ b/.github/actions/agents-schema-looker/action.yml
@@ -19,5 +19,5 @@ runs:
       env:
         AGENTS_SCHEMA_LOOKML_DIR: ${{ inputs.lookml-dir }}
       run: |
-        uvx --from "agents-schema==0.0.10" \
+        uvx --from "agents-schema==0.0.11" \
           agents-schema looker --lookml-dir "$AGENTS_SCHEMA_LOOKML_DIR"

--- a/.github/actions/agents-schema-omni/action.yml
+++ b/.github/actions/agents-schema-omni/action.yml
@@ -19,5 +19,5 @@ runs:
       env:
         AGENTS_SCHEMA_OMNI_DIR: ${{ inputs.omni-dir }}
       run: |
-        uvx --from "agents-schema==0.0.9" \
+        uvx --from "agents-schema==0.0.11" \
           agents-schema omni --omni-dir "$AGENTS_SCHEMA_OMNI_DIR"

--- a/.github/actions/agents-schema-osi/action.yml
+++ b/.github/actions/agents-schema-osi/action.yml
@@ -19,5 +19,5 @@ runs:
       env:
         AGENTS_SCHEMA_OSI_DIR: ${{ inputs.osi-dir }}
       run: |
-        uvx --from "agents-schema==0.0.10" \
+        uvx --from "agents-schema==0.0.11" \
           agents-schema osi --osi-dir "$AGENTS_SCHEMA_OSI_DIR"

--- a/.github/actions/agents-schema-sigma/action.yml
+++ b/.github/actions/agents-schema-sigma/action.yml
@@ -19,5 +19,5 @@ runs:
       env:
         AGENTS_SCHEMA_SIGMA_DIR: ${{ inputs.sigma-dir }}
       run: |
-        uvx --from "agents-schema==0.0.9" \
+        uvx --from "agents-schema==0.0.11" \
           agents-schema sigma --sigma-dir "$AGENTS_SCHEMA_SIGMA_DIR"

--- a/.github/actions/agents-schema-skills/action.yml
+++ b/.github/actions/agents-schema-skills/action.yml
@@ -21,7 +21,7 @@ runs:
     - name: Run skills ingestion
       shell: bash
       run: |
-        uvx --from "agents-schema==0.0.10" \
+        uvx --from "agents-schema==0.0.11" \
           agents-schema skills \
             --skills-dir "${{ inputs.skills-dir }}" \
             --provider "${{ inputs.provider }}"

--- a/.github/actions/agents-schema-snowflake-semantic/action.yml
+++ b/.github/actions/agents-schema-snowflake-semantic/action.yml
@@ -27,5 +27,5 @@ runs:
           [ -n "$view" ] && args+=(--semantic-view "$view")
         done <<< "$AGENTS_SCHEMA_SEMANTIC_VIEWS"
 
-        uvx --from "agents-schema==0.0.10" \
+        uvx --from "agents-schema==0.0.11" \
           agents-schema snowflake-semantic "${args[@]}"

--- a/.github/workflows/agents-schema-dbt.yml
+++ b/.github/workflows/agents-schema-dbt.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run dbt ingestion
-        uses: dbt-labs/agents_schema/.github/actions/agents-schema-dbt@v0.0.10
+        uses: dbt-labs/agents_schema/.github/actions/agents-schema-dbt@v0.0.11
         with:
           dbt-project-dir: ${{ inputs.dbt-project-dir }}
           dbt-profile-name: ${{ inputs.dbt-profile-name }}

--- a/.github/workflows/agents-schema-looker.yml
+++ b/.github/workflows/agents-schema-looker.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Looker ingestion
-        uses: dbt-labs/agents_schema/.github/actions/agents-schema-looker@v0.0.10
+        uses: dbt-labs/agents_schema/.github/actions/agents-schema-looker@v0.0.11
         with:
           lookml-dir: ${{ inputs.lookml-dir }}
         env:

--- a/.github/workflows/agents-schema-omni.yml
+++ b/.github/workflows/agents-schema-omni.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Omni ingestion
-        uses: dbt-labs/agents_schema/.github/actions/agents-schema-omni@v0.0.9
+        uses: dbt-labs/agents_schema/.github/actions/agents-schema-omni@v0.0.11
         with:
           omni-dir: ${{ inputs.omni-dir }}
         env:

--- a/.github/workflows/agents-schema-osi.yml
+++ b/.github/workflows/agents-schema-osi.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run OSI ingestion
-        uses: dbt-labs/agents_schema/.github/actions/agents-schema-osi@v0.0.10
+        uses: dbt-labs/agents_schema/.github/actions/agents-schema-osi@v0.0.11
         with:
           osi-dir: ${{ inputs.osi-dir }}
         env:

--- a/.github/workflows/agents-schema-sigma.yml
+++ b/.github/workflows/agents-schema-sigma.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Sigma ingestion
-        uses: dbt-labs/agents_schema/.github/actions/agents-schema-sigma@v0.0.9
+        uses: dbt-labs/agents_schema/.github/actions/agents-schema-sigma@v0.0.11
         with:
           sigma-dir: ${{ inputs.sigma-dir }}
         env:

--- a/.github/workflows/agents-schema-skills.yml
+++ b/.github/workflows/agents-schema-skills.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run skills ingestion
-        uses: dbt-labs/agents_schema/.github/actions/agents-schema-skills@v0.0.10
+        uses: dbt-labs/agents_schema/.github/actions/agents-schema-skills@v0.0.11
         with:
           skills-dir: ${{ inputs.skills-dir }}
           provider: ${{ inputs.provider }}

--- a/.github/workflows/agents-schema-snowflake-semantic.yml
+++ b/.github/workflows/agents-schema-snowflake-semantic.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run snowflake-semantic ingestion
-        uses: dbt-labs/agents_schema/.github/actions/agents-schema-snowflake-semantic@v0.0.10
+        uses: dbt-labs/agents_schema/.github/actions/agents-schema-snowflake-semantic@v0.0.11
         with:
           semantic-views: ${{ inputs.semantic-views }}
         env:

--- a/README.md
+++ b/README.md
@@ -236,11 +236,11 @@ source, examples, README, and spec.
 Pin exact tags in your workflows:
 
 ```yaml
-uses: dbt-labs/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.10
+uses: dbt-labs/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.11
 ```
 
 To upgrade, change only the tag in the `uses:` line. The current release tag is
-`v0.0.10`.
+`v0.0.11`.
 
 ### Specification
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -37,7 +37,7 @@ GitHub `release: published` event.
 5. Tag the release:
 
    ```bash
-   git tag v0.0.10
+   git tag v0.0.11
    git push origin main --tags
    ```
 

--- a/dbt-setup.md
+++ b/dbt-setup.md
@@ -101,7 +101,7 @@ on:
 
 jobs:
   agents-schema-dbt:
-    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.10
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.11
     with:
       dbt-project-dir: dbt_project
     secrets:

--- a/examples/workflows/dbt-looker-osi.yml
+++ b/examples/workflows/dbt-looker-osi.yml
@@ -7,21 +7,21 @@ on:
 
 jobs:
   agents-schema-dbt:
-    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.10
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.11
     with:
       dbt-project-dir: dbt_project
     secrets:
       WAREHOUSE_CREDENTIALS: ${{ secrets.WAREHOUSE_CREDENTIALS }}
 
   agents-schema-looker:
-    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-looker.yml@v0.0.10
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-looker.yml@v0.0.11
     with:
       lookml-dir: lookml
     secrets:
       WAREHOUSE_CREDENTIALS: ${{ secrets.WAREHOUSE_CREDENTIALS }}
 
   agents-schema-osi:
-    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-osi.yml@v0.0.10
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-osi.yml@v0.0.11
     with:
       osi-dir: osi
     secrets:

--- a/examples/workflows/dbt-looker.yml
+++ b/examples/workflows/dbt-looker.yml
@@ -7,14 +7,14 @@ on:
 
 jobs:
   agents-schema-dbt:
-    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.10
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.11
     with:
       dbt-project-dir: dbt_project
     secrets:
       WAREHOUSE_CREDENTIALS: ${{ secrets.WAREHOUSE_CREDENTIALS }}
 
   agents-schema-looker:
-    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-looker.yml@v0.0.10
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-looker.yml@v0.0.11
     with:
       lookml-dir: lookml
     secrets:

--- a/examples/workflows/dbt-with-parse.yml
+++ b/examples/workflows/dbt-with-parse.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   agents-schema-dbt:
-    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.10
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.11
     with:
       dbt-project-dir: dbt_project
       dbt-profile-name: analytics

--- a/examples/workflows/dbt.yml
+++ b/examples/workflows/dbt.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   agents-schema-dbt:
-    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.10
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-dbt.yml@v0.0.11
     with:
       dbt-project-dir: dbt_project
     secrets:

--- a/examples/workflows/omni.yml
+++ b/examples/workflows/omni.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   agents-schema-omni:
-    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-omni.yml@v0.0.9
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-omni.yml@v0.0.11
     with:
       omni-dir: omni/My Connection
     secrets:

--- a/examples/workflows/osi.yml
+++ b/examples/workflows/osi.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   agents-schema-osi:
-    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-osi.yml@v0.0.10
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-osi.yml@v0.0.11
     with:
       osi-dir: osi
     secrets:

--- a/examples/workflows/skills.yml
+++ b/examples/workflows/skills.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   agents-schema-skills:
-    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-skills.yml@v0.0.10
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-skills.yml@v0.0.11
     with:
       skills-dir: skills
       provider: fivetran

--- a/looker-setup.md
+++ b/looker-setup.md
@@ -99,7 +99,7 @@ on:
 
 jobs:
   agents-schema-looker:
-    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-looker.yml@v0.0.10
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-looker.yml@v0.0.11
     with:
       lookml-dir: lookml
     secrets:

--- a/omni-setup.md
+++ b/omni-setup.md
@@ -100,7 +100,7 @@ on:
 
 jobs:
   agents-schema-omni:
-    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-omni.yml@v0.0.9
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-omni.yml@v0.0.11
     with:
       omni-dir: omni/My Connection
     secrets:

--- a/osi-setup.md
+++ b/osi-setup.md
@@ -100,7 +100,7 @@ on:
 
 jobs:
   agents-schema-osi:
-    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-osi.yml@v0.0.10
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-osi.yml@v0.0.11
     with:
       osi-dir: osi
     secrets:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agents-schema"
-version = "0.0.10"
+version = "0.0.11"
 description = "Populate an in-warehouse agents.* schema from dbt manifests, OSI YAML, LookML, and markdown skills."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/sigma-setup.md
+++ b/sigma-setup.md
@@ -125,7 +125,7 @@ on:
 
 jobs:
   agents-schema-sigma:
-    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-sigma.yml@v0.0.9
+    uses: dbt-labs/agents_schema/.github/workflows/agents-schema-sigma.yml@v0.0.11
     with:
       sigma-dir: sigma
     secrets:

--- a/src/agents_schema/cli.py
+++ b/src/agents_schema/cli.py
@@ -6,7 +6,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from . import __version__, dbt, lookml, osi, sigma, skills, snowflake_semantic
+from . import __version__, dbt, lookml, omni, osi, sigma, skills, snowflake_semantic
 from .config import ConfigError
 from .dbt_profiles import dbt_adapter_package_from_profiles_file
 from .destinations import warehouse_type_from_env

--- a/tests/test_connector_root.py
+++ b/tests/test_connector_root.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import patch
 
-from agents_schema import dbt, lookml, osi, sigma, skills, snowflake_semantic
+from agents_schema import dbt, lookml, omni, osi, sigma, skills, snowflake_semantic
 from agents_schema.skills import SkillFile
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -15,7 +15,7 @@ resolution-markers = [
 
 [[package]]
 name = "agents-schema"
-version = "0.0.10"
+version = "0.0.11"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Release 0.0.11

`omni` and `sigma` were merged into `main` after the `v0.0.10` tag was cut
and published to PyPI, but the version in `pyproject.toml` was never
bumped. No published release actually contains these subcommands, so the
`agents-schema-omni` and `agents-schema-sigma` actions fail with an
argparse "invalid choice" error regardless of which version (`0.0.9` or
`0.0.10`) they're pinned to — changing the pin alone can't fix it.

### What changed
- `src/agents_schema/cli.py` — `omni` was missing from the module import,
  causing a `NameError` before the CLI even reached argparse dispatch.
- `tests/test_connector_root.py` — the same missing `omni` import let this
  slip through the test suite undetected, which is how `0.0.10` shipped
  broken in the first place.
- `pyproject.toml` / `uv.lock` — version bump `0.0.10 → 0.0.11`.
- `.github/actions/*/action.yml`, `.github/workflows/agents-schema-*.yml`,
  `examples/workflows/*.yml`, `README.md`, `RELEASING.md`,
  `dbt-setup.md`, `looker-setup.md`, `omni-setup.md`, `osi-setup.md`,
  `sigma-setup.md` — repointed every `agents-schema==0.0.9`/`0.0.10` and
  `@v0.0.9`/`@v0.0.10` reference to `0.0.11`.

### Notes
- `uv run python -m unittest discover -s tests` — 130 passing.
- `uv build && uvx twine check dist/*` — both the `0.0.11` wheel and
  sdist pass.
- `agents-schema omni --help` / `agents-schema sigma --help` verified
  locally against the fixed CLI.
- This PR does not tag or publish the release. Merge, then follow
  `RELEASING.md` (tag `v0.0.11`, push tags, create the GitHub Release) to
  trigger `publish-pypi.yml` — until that lands, these pins still resolve
  to nothing on PyPI.

### Scope
Deliberately limited to this commit only. A follow-up change that makes
each action resolve its `agents-schema` PyPI version dynamically (instead
of a hardcoded pin) is on `main` locally but not included in this PR.